### PR TITLE
Update readme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in fluent-plugin-kafka-poseidon.gemspec
+# Specify your gem's dependencies in fluent-plugin-kafka.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -140,15 +140,15 @@ Install snappy module before you use snappy compression.
 
 #### Load balancing
 
-Messages will be sent broker in a round-robin manner as default by Poseidon, but you can set `default_partition_key` in config file to route messages to a specific broker.
+Messages will be assigned a partition at random as default by ruby-kafka, but messages with the same partition key will always be assigned to the same partition by setting `default_partition_key` in config file.
 If key name `partition_key` exists in a message, this plugin set its value of partition_key as key.
 
 |default_partition_key|partition_key| behavior |
 | --- | --- | --- |
-|Not set|Not exists| All messages are sent in round-robin |
-|Set| Not exists| All messages are sent to specific broker |
-|Not set| Exists | Messages which have partition_key record are sent to specific broker, others are sent in round-robin|
-|Set| Exists | Messages which have partition_key record are sent to specific broker with parition_key, others are sent to specific broker with default_parition_key|
+|Not set|Not exists| All messages are assigned a partition at random |
+|Set| Not exists| All messages are assigned to the specific partition |
+|Not set| Exists | Messages which have partition_key record are assigned to the specific partition, others are assigned a partition at random |
+|Set| Exists | Messages which have partition_key record are assigned to the specific partition with parition_key, others are assigned to the specific partition with default_parition_key |
 
 
 ### Buffered output plugin


### PR DESCRIPTION
This PR is going to update READ.md.

* Poseidon is already not being used and ruby-kafka is used instead of Poseidon.
* In ruby-kafka, the simplest option is to not specify a message key, partition key, or partition number, in which case the message will be assigned a partition at random.