### PR TITLE
Change default required_acks value to -1, wait all acks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This plugin uses ruby-kafka producer for writing data. For performance and relia
 
       # ruby-kafka producer options
       max_send_retries  (integer)     :default => 1
-      required_acks     (integer)     :default => 0
+      required_acks     (integer)     :default => -1
       ack_timeout       (integer)     :default => nil (Use default of ruby-kafka)
       compression_codec (gzip|snappy) :default => nil
     </match>
@@ -127,7 +127,7 @@ This plugin uses ruby-kafka producer for writing data. For performance and relia
 Supports following ruby-kafka::Producer options.
 
 - max_send_retries - default: 1 - Number of times to retry sending of messages to a leader.
-- required_acks - default: 0 - The number of acks required per request.
+- required_acks - default: -1 - The number of acks required per request.
 - ack_timeout - default: nil - How long the producer waits for acks. The unit is seconds.
 - compression_codec - default: nil - The codec the producer uses to compress messages.
 
@@ -173,7 +173,7 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
 
       # ruby-kafka producer options
       max_send_retries    (integer)     :default => 1
-      required_acks       (integer)     :default => 0
+      required_acks       (integer)     :default => -1
       ack_timeout         (integer)     :default => nil (Use default of ruby-kafka)
       compression_codec   (gzip|snappy) :default => nil (No compression)
     </match>
@@ -181,7 +181,7 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
 Supports following ruby-kafka's producer options.
 
 - max_send_retries - default: 1 - Number of times to retry sending of messages to a leader.
-- required_acks - default: 0 - The number of acks required per request.
+- required_acks - default: -1 - The number of acks required per request.
 - ack_timeout - default: nil - How long the producer waits for acks. The unit is seconds.
 - compression_codec - default: nil - The codec the producer uses to compress messages.
 

--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -26,7 +26,7 @@ DESC
   # ruby-kafka producer options
   config_param :max_send_retries, :integer, :default => 1,
                :desc => "Number of times to retry sending of messages to a leader."
-  config_param :required_acks, :integer, :default => 0,
+  config_param :required_acks, :integer, :default => -1,
                :desc => "The number of acks required per request."
   config_param :ack_timeout, :integer, :default => nil,
                :desc => "How long the producer waits for acks."

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -33,7 +33,7 @@ DESC
   # ruby-kafka producer options
   config_param :max_send_retries, :integer, :default => 1,
                :desc => "Number of times to retry sending of messages to a leader."
-  config_param :required_acks, :integer, :default => 0,
+  config_param :required_acks, :integer, :default => -1,
                :desc => "The number of acks required per request."
   config_param :ack_timeout, :time, :default => nil,
                :desc => "How long the producer waits for acks."


### PR DESCRIPTION
`required_acks 0` is fire-and-forget and
this is not good default value for almost users.
Default behaviour should be safe.

Refer: https://github.com/fluent/fluent-plugin-kafka/issues/69