### PR TITLE
Add max_bytes option to in_kafka_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Consume events by kafka consumer group features..
       time_format <string (Optional when use_record_time is used)>
 
       # ruby-kafka consumer options
+      max_bytes               (integer) :default => 1048576
       max_wait_time           (integer) :default => nil (Use default of ruby-kafka)
       min_bytes               (integer) :default => nil (Use default of ruby-kafka)
       offset_commit_interval  (integer) :default => nil (Use default of ruby-kafka)

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -27,6 +27,8 @@ class Fluent::KafkaGroupInput < Fluent::Input
                :desc => "Time format to be used to parse 'time' filed."
 
   # Kafka consumer options
+  config_param :max_bytes, :integer, :default => 1048576,
+               :desc => "Maximum number of bytes to fetch."
   config_param :max_wait_time, :integer, :default => nil,
                :desc => "How long to block until the server sends us data."
   config_param :min_bytes, :integer, :default => nil,
@@ -144,7 +146,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
   def setup_consumer
     consumer = @kafka.consumer(@consumer_opts)
     @topics.each { |topic|
-      consumer.subscribe(topic, start_from_beginning: @start_from_beginning)
+      consumer.subscribe(topic, start_from_beginning: @start_from_beginning, max_bytes_per_partition: @max_bytes)
     }
     consumer
   end


### PR DESCRIPTION
* Related issue is #108.
* ruby-kafka's subscribe function supports max_bytes_per_partition parameter.
  * refer to [link](https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/consumer.rb#L83)
  * default value is 1048576(1M).