### PR TITLE
Add max_send_limit_bytes option to avoid MessageSizeTooLarge

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
       # See fluentd document for buffer related parameters: http://docs.fluentd.org/articles/buffer-plugin-overview
 
       # ruby-kafka producer options
-      max_send_retries    (integer)     :default => 1
-      required_acks       (integer)     :default => -1
-      ack_timeout         (integer)     :default => nil (Use default of ruby-kafka)
-      compression_codec   (gzip|snappy) :default => nil (No compression)
+      max_send_retries     (integer)     :default => 1
+      required_acks        (integer)     :default => -1
+      ack_timeout          (integer)     :default => nil (Use default of ruby-kafka)
+      compression_codec    (gzip|snappy) :default => nil (No compression)
+      max_send_limit_bytes (integer)     :default => nil (No drop)
     </match>
 
 `<formatter name>` of `output_data_type` uses fluentd's formatter plugins. See [formatter article](http://docs.fluentd.org/articles/formatter-plugin-overview).
@@ -155,6 +156,7 @@ Supports following ruby-kafka's producer options.
 - required_acks - default: -1 - The number of acks required per request. If you need flush performance, set lower value, e.g. 1, 2.
 - ack_timeout - default: nil - How long the producer waits for acks. The unit is seconds.
 - compression_codec - default: nil - The codec the producer uses to compress messages.
+- max_send_limit_bytes - default: nil - Max byte size to send message to avoid MessageSizeTooLarge. For example, if you set 1000000(message.max.bytes in kafka), Message more than 1000000 byes will be dropped.
 
 See also [Kafka::Client](http://www.rubydoc.info/gems/ruby-kafka/Kafka/Client) for more detailed documentation about ruby-kafka.
 

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -62,6 +62,7 @@ DESC
 The codec the producer uses to compress messages.
 Supported codecs: (gzip|snappy)
 DESC
+  config_param :max_send_limit_bytes, :size, :default => nil
 
   config_param :time_format, :string, :default => nil
 
@@ -242,6 +243,10 @@ DESC
 
           record_buf = @formatter_proc.call(tag, time, record)
           record_buf_bytes = record_buf.bytesize
+          if @max_send_limit_bytes && record_buf_bytes > @max_send_limit_bytes
+            log.warn "record size exceeds max_send_limit_bytes. Skip event:", :time => time, :record => record
+            next
+          end
         rescue StandardError => e
           log.warn "unexpected error during format record. Skip broken event:", :error => e.to_s, :error_class => e.class.to_s, :time => time, :record => record
           next


### PR DESCRIPTION
This pull request is related to https://github.com/fluent/fluent-plugin-kafka/issues/117

And it's similar to https://github.com/fluent/fluent-plugin-kafka/issues/80

fluentd configuration file
```
  <source>
    @type forward
  </source>
  <match test.**>
    type kafka_buffered
    brokers host1:6667,host2:6667,host3:6667
    buffer_chunk_limit 32M
    flush_at_shutdown true
    kafka_agg_max_bytes 40960
    output_include_tag true
    output_include_time true
    time_format %Y-%m-%dT%H:%M:%S%z
    output_data_type json
    flush_interval 1
    num_threads 10
    required_acks 1
    max_send_limit_bytes 100
  </match>
```

fluentd-cat command
```
$ echo '{"hoge":"fugaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' | fluent-cat test.fuga
```

warn log
```
2017-03-27 16:26:49 +0900 [warn]: record size exceeds max_send_limit_bytes. Skip event: time=1490599608 record={"hoge"=>"fugaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "time"=>"2017-03-27T16:26:48+0900", "tag"=>"test.fuga"}
```