### PR TITLE
handling BufferOverflow exception in out_kafka

### DIFF
--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -184,7 +184,14 @@ DESC
         value = @formatter_proc.call(tag, time, record)
 
         log.on_trace { log.trace("message will send to #{topic} with partition_key: #{partition_key}, partition: #{partition}, message_key: #{message_key} and value: #{record_buf}.") }
-        producer.produce(value, topic: topic, key: message_key, partition: partition, partition_key: partition_key)
+	begin
+          producer.produce(value, topic: topic, key: message_key, partition: partition, partition_key: partition_key)
+	rescue Kafka::BufferOverflow => e
+	  log.warn "BufferOverflow occurred: #{e}"
+	  log.info "Trying to deliver the messages to prevent the buffer from overflowing again."
+	  producer.deliver_messages
+	  log.info "Recovered from BufferOverflow successfully`"
+	end
       end
 
       producer.deliver_messages


### PR DESCRIPTION
Solves https://github.com/fluent/fluent-plugin-kafka/issues/120.

When the buffer overflows, it delivers the messages and continues.