### PR TITLE
make parameters of ruby-kafka configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
       required_acks       (integer)     :default => -1
       ack_timeout         (integer)     :default => nil (Use default of ruby-kafka)
       compression_codec   (gzip|snappy) :default => nil (No compression)
+      max_buffer_size     (integer)     :default => nil (Use default of ruby-kafka)
+      max_buffer_bytesize (integer)     :default => nil (Use default of ruby-kafka) 
     </match>
 
 `<formatter name>` of `output_data_type` uses fluentd's formatter plugins. See [formatter article](http://docs.fluentd.org/articles/formatter-plugin-overview).
@@ -154,6 +156,8 @@ Supports following ruby-kafka's producer options.
 - required_acks - default: -1 - The number of acks required per request. If you need flush performance, set lower value, e.g. 1, 2.
 - ack_timeout - default: nil - How long the producer waits for acks. The unit is seconds.
 - compression_codec - default: nil - The codec the producer uses to compress messages.
+- max_buffer_size - default: ruby-kafka default (1000) - The number of messages allowed in the buffer.
+- max_buffer_bytesize - default: ruby-kafka default (10_000_000) - The maximum size of the buffer in bytes.
 
 See also [Kafka::Client](http://www.rubydoc.info/gems/ruby-kafka/Kafka/Client) for more detailed documentation about ruby-kafka.
 
@@ -203,10 +207,12 @@ This plugin uses ruby-kafka producer for writing data. For performance and relia
       exclude_partition_key (bool) :default => false
 
       # ruby-kafka producer options
-      max_send_retries  (integer)     :default => 1
-      required_acks     (integer)     :default => -1
-      ack_timeout       (integer)     :default => nil (Use default of ruby-kafka)
-      compression_codec (gzip|snappy) :default => nil
+      max_send_retries    (integer)     :default => 1
+      required_acks       (integer)     :default => -1
+      ack_timeout         (integer)     :default => nil (Use default of ruby-kafka) 
+      compression_codec   (gzip|snappy) :default => nil
+      max_buffer_size     (integer)     :default => nil (Use default of ruby-kafka)
+      max_buffer_bytesize (integer)     :default => nil (Use default of ruby-kafka) 
     </match>
 
 This plugin also supports ruby-kafka related parameters. See Buffered output plugin section.

--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
       required_acks       (integer)     :default => -1
       ack_timeout         (integer)     :default => nil (Use default of ruby-kafka)
       compression_codec   (gzip|snappy) :default => nil (No compression)
-      max_buffer_size     (integer)     :default => nil (Use default of ruby-kafka)
-      max_buffer_bytesize (integer)     :default => nil (Use default of ruby-kafka) 
     </match>
 
 `<formatter name>` of `output_data_type` uses fluentd's formatter plugins. See [formatter article](http://docs.fluentd.org/articles/formatter-plugin-overview).
@@ -156,8 +154,6 @@ Supports following ruby-kafka's producer options.
 - required_acks - default: -1 - The number of acks required per request. If you need flush performance, set lower value, e.g. 1, 2.
 - ack_timeout - default: nil - How long the producer waits for acks. The unit is seconds.
 - compression_codec - default: nil - The codec the producer uses to compress messages.
-- max_buffer_size - default: ruby-kafka default (1000) - The number of messages allowed in the buffer.
-- max_buffer_bytesize - default: ruby-kafka default (10_000_000) - The maximum size of the buffer in bytes.
 
 See also [Kafka::Client](http://www.rubydoc.info/gems/ruby-kafka/Kafka/Client) for more detailed documentation about ruby-kafka.
 

--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -54,6 +54,12 @@ DESC
 
   config_param :time_format, :string, :default => nil
 
+  config_param :max_buffer_size, :integer, :default => nil,
+               :desc => "Number of messages to be buffered by the kafka producer."
+
+  config_param :max_buffer_bytesize, :integer, :default => nil,
+               :desc => "Maximum size in bytes to be buffered."
+
   include Fluent::KafkaPluginUtil::SSLSettings
 
   attr_accessor :output_data_type
@@ -122,6 +128,8 @@ DESC
     @producer_opts = {max_retries: @max_send_retries, required_acks: @required_acks}
     @producer_opts[:ack_timeout] = @ack_timeout if @ack_timeout
     @producer_opts[:compression_codec] = @compression_codec.to_sym if @compression_codec
+    @producer_opts[:max_buffer_size] = @max_buffer_size if @max_buffer_size
+    @producer_opts[:max_buffer_bytesize] = @max_buffer_bytesize if @max_buffer_bytesize
   end
 
   def start

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -62,6 +62,11 @@ DESC
 The codec the producer uses to compress messages.
 Supported codecs: (gzip|snappy)
 DESC
+  config_param :max_buffer_size, :integer, :default => nil,
+	                 :desc => "Number of messages to be buffered by the kafka producer."
+
+  config_param :max_buffer_bytesize, :integer, :default => nil,
+	                   :desc => "Maximum size in bytes to be buffered."
 
   config_param :time_format, :string, :default => nil
 
@@ -141,6 +146,8 @@ DESC
     @producer_opts = {max_retries: @max_send_retries, required_acks: @required_acks}
     @producer_opts[:ack_timeout] = @ack_timeout if @ack_timeout
     @producer_opts[:compression_codec] = @compression_codec.to_sym if @compression_codec
+    @producer_opts[:max_buffer_size] = @max_buffer_size if @max_buffer_size
+    @producer_opts[:max_buffer_bytesize] = @max_buffer_bytesize if @max_buffer_bytesize
   end
 
   def start

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -62,11 +62,6 @@ DESC
 The codec the producer uses to compress messages.
 Supported codecs: (gzip|snappy)
 DESC
-  config_param :max_buffer_size, :integer, :default => nil,
-	                 :desc => "Number of messages to be buffered by the kafka producer."
-
-  config_param :max_buffer_bytesize, :integer, :default => nil,
-	                   :desc => "Maximum size in bytes to be buffered."
 
   config_param :time_format, :string, :default => nil
 
@@ -146,8 +141,6 @@ DESC
     @producer_opts = {max_retries: @max_send_retries, required_acks: @required_acks}
     @producer_opts[:ack_timeout] = @ack_timeout if @ack_timeout
     @producer_opts[:compression_codec] = @compression_codec.to_sym if @compression_codec
-    @producer_opts[:max_buffer_size] = @max_buffer_size if @max_buffer_size
-    @producer_opts[:max_buffer_bytesize] = @max_buffer_bytesize if @max_buffer_bytesize
   end
 
   def start


### PR DESCRIPTION
Makes easy to mitigate https://github.com/fluent/fluent-plugin-kafka/issues/120.

Makes the parameters max_buffer_size and max_buffer_bytesize of ruby-kafka configurable.