### PR TITLE
Add discard_kafka_delivery_failed option to handle Kafka::DeliveryFailed

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,12 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
       # See fluentd document for buffer related parameters: http://docs.fluentd.org/articles/buffer-plugin-overview
 
       # ruby-kafka producer options
-      max_send_retries     (integer)     :default => 1
-      required_acks        (integer)     :default => -1
-      ack_timeout          (integer)     :default => nil (Use default of ruby-kafka)
-      compression_codec    (gzip|snappy) :default => nil (No compression)
-      max_send_limit_bytes (integer)     :default => nil (No drop)
+      max_send_retries             (integer)     :default => 1
+      required_acks                (integer)     :default => -1
+      ack_timeout                  (integer)     :default => nil (Use default of ruby-kafka)
+      compression_codec            (gzip|snappy) :default => nil (No compression)
+      max_send_limit_bytes         (integer)     :default => nil (No drop)
+      skip_kafka_delivery_failed   (bool)        :default => false (No skip)
     </match>
 
 `<formatter name>` of `output_data_type` uses fluentd's formatter plugins. See [formatter article](http://docs.fluentd.org/articles/formatter-plugin-overview).
@@ -157,6 +158,7 @@ Supports following ruby-kafka's producer options.
 - ack_timeout - default: nil - How long the producer waits for acks. The unit is seconds.
 - compression_codec - default: nil - The codec the producer uses to compress messages.
 - max_send_limit_bytes - default: nil - Max byte size to send message to avoid MessageSizeTooLarge. For example, if you set 1000000(message.max.bytes in kafka), Message more than 1000000 byes will be dropped.
+- skip_kafka_delivery_failed - default: false - skip the record where [Kafka::DeliveryFailed](http://www.rubydoc.info/gems/ruby-kafka/Kafka/DeliveryFailed) occurred
 
 See also [Kafka::Client](http://www.rubydoc.info/gems/ruby-kafka/Kafka/Client) for more detailed documentation about ruby-kafka.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
       ack_timeout                  (integer)     :default => nil (Use default of ruby-kafka)
       compression_codec            (gzip|snappy) :default => nil (No compression)
       max_send_limit_bytes         (integer)     :default => nil (No drop)
-      skip_kafka_delivery_failed   (bool)        :default => false (No skip)
+      discard_kafka_delivery_failed   (bool)        :default => false (No discard)
     </match>
 
 `<formatter name>` of `output_data_type` uses fluentd's formatter plugins. See [formatter article](http://docs.fluentd.org/articles/formatter-plugin-overview).
@@ -158,7 +158,7 @@ Supports following ruby-kafka's producer options.
 - ack_timeout - default: nil - How long the producer waits for acks. The unit is seconds.
 - compression_codec - default: nil - The codec the producer uses to compress messages.
 - max_send_limit_bytes - default: nil - Max byte size to send message to avoid MessageSizeTooLarge. For example, if you set 1000000(message.max.bytes in kafka), Message more than 1000000 byes will be dropped.
-- skip_kafka_delivery_failed - default: false - skip the record where [Kafka::DeliveryFailed](http://www.rubydoc.info/gems/ruby-kafka/Kafka/DeliveryFailed) occurred
+- discard_kafka_delivery_failed - default: false - discard the record where [Kafka::DeliveryFailed](http://www.rubydoc.info/gems/ruby-kafka/Kafka/DeliveryFailed) occurred
 
 See also [Kafka::Client](http://www.rubydoc.info/gems/ruby-kafka/Kafka/Client) for more detailed documentation about ruby-kafka.
 


### PR DESCRIPTION
Hi, I use Kafka 0.9 and fluent-plugin-kafka 0.5.4.

If user uses a period ('.') and underscore ('_') as kafka topic name, it's troublesome.

For example, user creates a.a_a topic
```
$ bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic a.a_a
WARNING: Due to limitations in metric names, topics with a period ('.') or underscore ('_') could collide. To avoid issues it is best to use either, but not both.
Created topic "a.a_a".
```

but, user sends message to a.a.a topic.
```
  <source>
    @type forward
  </source>
  <match a.a.a>
    type kafka_buffered
    brokers localhost:9092
    flush_interval 1
  </match>
```

```
$ echo '{"hoge":"fuga"}' | fluent-cat a.a.a
```

Error occurs as follows
```
2017-04-18 10:52:43 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2017-04-18 10:53:51 +0900 error_class="Kafka::DeliveryFailed" error="Failed to assign partitions to 1 messages" plugin_id="object:3fe35d43b5cc"
  2017-04-18 10:52:43 +0900 [warn]: suppressed same stacktrace
2017-04-18 10:53:53 +0900 [warn]: Send exception occurred: Failed to assign partitions to 1 messages
2017-04-18 10:53:53 +0900 [warn]: Exception Backtrace : /.../vendor/bundle/gems/ruby-kafka-0.3.17/lib/kafka/producer.rb:325:in `deliver_messages_with_retries'
/.../vendor/bundle/gems/ruby-kafka-0.3.17/lib/kafka/producer.rb:243:in `block in deliver_messages'
/.../vendor/bundle/gems/ruby-kafka-0.3.17/lib/kafka/instrumenter.rb:21:in `instrument'
/.../vendor/bundle/gems/ruby-kafka-0.3.17/lib/kafka/producer.rb:236:in `deliver_messages'
/.../vendor/bundle/gems/fluent-plugin-kafka-0.5.4/lib/fluent/plugin/out_kafka_buffered.rb:271:in `write'
/.../vendor/bundle/gems/fluentd-0.12.33/lib/fluent/buffer.rb:354:in `write_chunk'
/.../vendor/bundle/gems/fluentd-0.12.33/lib/fluent/buffer.rb:333:in `pop'
/.../vendor/bundle/gems/fluentd-0.12.33/lib/fluent/output.rb:342:in `try_flush'
/.../vendor/bundle/gems/fluentd-0.12.33/lib/fluent/output.rb:149:in `run'
```

User may create a troublesome kafka topic because user can create fluentd tag(kafka topic) freely in my environment.

IMHO, it's not necessary to retry if Kafka::DeliveryFailed error occurs because retry doesn't succeed and increases fluentd buffer size.

So, I want to skip such kind a record.

I want to add a option(skip_kafka_delivery_failed) because fluent-plugin-kafka become more robust.
```
  <source>
    @type forward
  </source>
  <match a.a.a>
    type kafka_buffered
    brokers localhost:9092
    flush_interval 1
    skip_kafka_delivery_failed true
  </match>
 ```
 
 log
 ```
2017-04-18 13:02:49 +0900 [warn]: DeliveryFailed occurred. Skip broken event: error="Failed to assign partitions to 1 messages" error_class="Kafka::DeliveryFailed" tag="a.a.a"
 ```

Default setting of skip_kafka_delivery_failed is false, so I think that there is no regression for existing users.
