### PR TITLE
Add kafka_agg_max_messages option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
       required_acks                (integer)     :default => -1
       ack_timeout                  (integer)     :default => nil (Use default of ruby-kafka)
       compression_codec            (gzip|snappy) :default => nil (No compression)
+      kafka_agg_max_bytes          (integer)     :default => 4096
+      kafka_agg_max_messages       (integer)     :default => nil (No limit)
       max_send_limit_bytes         (integer)     :default => nil (No drop)
       discard_kafka_delivery_failed   (bool)        :default => false (No discard)
     </match>
@@ -157,6 +159,8 @@ Supports following ruby-kafka's producer options.
 - required_acks - default: -1 - The number of acks required per request. If you need flush performance, set lower value, e.g. 1, 2.
 - ack_timeout - default: nil - How long the producer waits for acks. The unit is seconds.
 - compression_codec - default: nil - The codec the producer uses to compress messages.
+- kafka_agg_max_bytes - default: 4096 - Maximum value of total message size to be included in one batch transmission.
+- kafka_agg_max_messages - default: nil - Maximum number of messages to include in one batch transmission.
 - max_send_limit_bytes - default: nil - Max byte size to send message to avoid MessageSizeTooLarge. For example, if you set 1000000(message.max.bytes in kafka), Message more than 1000000 byes will be dropped.
 - discard_kafka_delivery_failed - default: false - discard the record where [Kafka::DeliveryFailed](http://www.rubydoc.info/gems/ruby-kafka/Kafka/DeliveryFailed) occurred
 

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -48,6 +48,7 @@ Set true to remove topic name key from data
 DESC
 
   config_param :kafka_agg_max_bytes, :size, :default => 4*1024  #4k
+  config_param :kafka_agg_max_messages, :integer, :default => nil
   config_param :get_kafka_client_log, :bool, :default => false
 
   # ruby-kafka producer options
@@ -271,8 +272,8 @@ DESC
           next
         end
 
-        if (messages > 0) and (messages_bytes + record_buf_bytes > @kafka_agg_max_bytes)
-          log.debug { "#{messages} messages send because reaches kafka_agg_max_bytes" }
+        if (messages > 0) and (messages_bytes + record_buf_bytes > @kafka_agg_max_bytes) or (@kafka_agg_max_messages && messages >= @kafka_agg_max_messages)
+          log.debug { "#{messages} messages send because reaches the limit of batch transmission." }
           deliver_messages(producer, tag)
           messages = 0
           messages_bytes = 0


### PR DESCRIPTION
Hi.
I'd like to add an option for batch transfer, which sets an upper limit on the number of messages.
Currently, `kafka_agg_max_bytes` can set an upper limit on the number of bytes, but we also want to limit the number of messages.
If only `kafka_agg_max_bytes` is used, there is a possibility that a lot of small logs are packed in one batch.
The number of logs in one batch affects the number of duplicate logs at retransmission, so I would like to control this with the parameter `kafka_agg_max_messages`.
Also, `kafka_agg_max_bytes` is an important parameter affecting throughput, but there is no explanation in the `README.md`. I think that adding the explanation to the `README.md` is more helpful to the user.

