### PR TITLE
Add statsd and datadog monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
       kafka_agg_max_bytes          (integer)     :default => 4096
       kafka_agg_max_messages       (integer)     :default => nil (No limit)
       max_send_limit_bytes         (integer)     :default => nil (No drop)
-      discard_kafka_delivery_failed   (bool)        :default => false (No discard)
+      discard_kafka_delivery_failed   (bool)     :default => false (No discard)
+      statsd_monitoring            (bool)        :default => false
+      datadog_monitoring           (bool)        :default => false
     </match>
 
 `<formatter name>` of `output_data_type` uses fluentd's formatter plugins. See [formatter article](http://docs.fluentd.org/articles/formatter-plugin-overview).
@@ -172,6 +174,10 @@ Supports following ruby-kafka's producer options.
 - kafka_agg_max_messages - default: nil - Maximum number of messages to include in one batch transmission.
 - max_send_limit_bytes - default: nil - Max byte size to send message to avoid MessageSizeTooLarge. For example, if you set 1000000(message.max.bytes in kafka), Message more than 1000000 byes will be dropped.
 - discard_kafka_delivery_failed - default: false - discard the record where [Kafka::DeliveryFailed](http://www.rubydoc.info/gems/ruby-kafka/Kafka/DeliveryFailed) occurred
+- statsd_monitoring - default: false - enable statsd monitoring
+- datadog_monitoring - default: false - enable datadog monitoring
+
+If you want to know about detail of monitoring, see also https://github.com/zendesk/ruby-kafka#monitoring
 
 See also [Kafka::Client](http://www.rubydoc.info/gems/ruby-kafka/Kafka/Client) for more detailed documentation about ruby-kafka.
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ This plugin uses ruby-kafka producer for writing data. This plugin works with re
       kafka_agg_max_messages       (integer)     :default => nil (No limit)
       max_send_limit_bytes         (integer)     :default => nil (No drop)
       discard_kafka_delivery_failed   (bool)     :default => false (No discard)
-      statsd_monitoring            (bool)        :default => false
-      datadog_monitoring           (bool)        :default => false
+      monitoring_list              (array)       :default => []
     </match>
 
 `<formatter name>` of `output_data_type` uses fluentd's formatter plugins. See [formatter article](http://docs.fluentd.org/articles/formatter-plugin-overview).
@@ -174,8 +173,7 @@ Supports following ruby-kafka's producer options.
 - kafka_agg_max_messages - default: nil - Maximum number of messages to include in one batch transmission.
 - max_send_limit_bytes - default: nil - Max byte size to send message to avoid MessageSizeTooLarge. For example, if you set 1000000(message.max.bytes in kafka), Message more than 1000000 byes will be dropped.
 - discard_kafka_delivery_failed - default: false - discard the record where [Kafka::DeliveryFailed](http://www.rubydoc.info/gems/ruby-kafka/Kafka/DeliveryFailed) occurred
-- statsd_monitoring - default: false - enable statsd monitoring
-- datadog_monitoring - default: false - enable datadog monitoring
+- monitoring_list - default: [] - library to be used to monitor. statsd and datadog are supported
 
 If you want to know about detail of monitoring, see also https://github.com/zendesk/ruby-kafka#monitoring
 

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -74,6 +74,9 @@ Add a regular expression to capture ActiveSupport notifications from the Kafka c
 requires activesupport gem - records will be generated under fluent_kafka_stats.**
 DESC
 
+  config_param :statsd_monitoring, :bool, :default => false
+  config_param :datadog_monitoring, :bool, :default => false
+
   include Fluent::KafkaPluginUtil::SSLSettings
   include Fluent::KafkaPluginUtil::SaslSettings
 
@@ -166,6 +169,16 @@ DESC
         message = event.payload.respond_to?(:stringify_keys) ? event.payload.stringify_keys : event.payload
         @router.emit("fluent_kafka_stats.#{event.name}", Time.now.to_i, message)
       end
+    end
+
+    if @statsd_monitoring
+      require 'kafka/statsd'
+      log.info 'statsd monitoring started'
+    end
+
+    if @datadog_monitoring
+      require 'kafka/datadog'
+      log.info 'datadog monitoring started'
     end
   end
 

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -74,7 +74,8 @@ Add a regular expression to capture ActiveSupport notifications from the Kafka c
 requires activesupport gem - records will be generated under fluent_kafka_stats.**
 DESC
 
-  config_param :monitoring_list, :array, :default => []
+  config_param :monitoring_list, :array, :default => [],
+               :desc => "library to be used to monitor. statsd and datadog are supported"
 
   include Fluent::KafkaPluginUtil::SSLSettings
   include Fluent::KafkaPluginUtil::SaslSettings

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -74,8 +74,7 @@ Add a regular expression to capture ActiveSupport notifications from the Kafka c
 requires activesupport gem - records will be generated under fluent_kafka_stats.**
 DESC
 
-  config_param :statsd_monitoring, :bool, :default => false
-  config_param :datadog_monitoring, :bool, :default => false
+  config_param :monitoring_list, :array, :default => []
 
   include Fluent::KafkaPluginUtil::SSLSettings
   include Fluent::KafkaPluginUtil::SaslSettings
@@ -171,15 +170,10 @@ DESC
       end
     end
 
-    if @statsd_monitoring
-      require 'kafka/statsd'
-      log.info 'statsd monitoring started'
-    end
-
-    if @datadog_monitoring
-      require 'kafka/datadog'
-      log.info 'datadog monitoring started'
-    end
+    @monitoring_list.each { |m|
+      require "kafka/#{m}"
+      log.info "#{m} monitoring started"
+    }
   end
 
   def start


### PR DESCRIPTION
#139 

ruby-kafka supports Statsd and Datadog monitoring.
https://github.com/zendesk/ruby-kafka#monitoring

ruby-kafka 4.0 supports statsd.
https://github.com/zendesk/ruby-kafka/pull/373

This pull request enables to monitor kafka client by using datadog or statsd

sample fluentd conf
```
  <source>
    @type forward
  </source>
  <match aaa>
    type kafka_buffered
    statsd_monitoring true
    get_kafka_client_log true
    brokers localhost:9092
    flush_interval 1
  </match>
```

sample Gemfile
```
source 'https://rubygems.org'

gem "fluent-plugin-kafka",:git=>"https://github.com/wyukawa/fluent-plugin-kafka.git", :ref => "281f1b66cd303ea8b16333364dba21771bbad922"
gem "statsd-ruby"
gem "activesupport", "5.1.2"
gem "fluentd", "0.12.33"
```

I confirmed by using https://github.com/prometheus/statsd_exporter

I can't confirm datadog monitoring because I don't use datadog.

Thanks