### PR TITLE
Parsed ltsv format, records' keys should be string, not symbol.

### DIFF
--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -122,7 +122,7 @@ class Fluent::KafkaInput < Fluent::Input
     when 'ltsv'
       require 'ltsv'
       Proc.new { |msg, te|
-        r = LTSV.parse(msg.value).first
+        r = LTSV.parse(msg.value, {:symbolize_keys => false}).first
         add_offset_in_hash(r, te, msg.offset) if @add_offset_in_record
         r
       }

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -111,7 +111,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
       Proc.new { |msg| Yajl::Parser.parse(msg.value) }
     when 'ltsv'
       require 'ltsv'
-      Proc.new { |msg| LTSV.parse(msg.value).first }
+      Proc.new { |msg| LTSV.parse(msg.value, {:symbolize_keys => false}).first }
     when 'msgpack'
       require 'msgpack'
       Proc.new { |msg| MessagePack.unpack(msg.value) }


### PR DESCRIPTION
When I used this plugin for consuming ltsv format topics from kafka brokers.

```td-agent.conf
<source>
   @type kafka_group

  brokers              kafka01:9092,kafka02:9092,kafka03:9092,
  consumer_group       test_consumer01
  topics               target_topics01
  format               ltsv
  add_prefix           kafka
  use_record_time      true
  time_format          %Y-%m-%dT%H:%M:%S%:z

  # ruby-kafka consumer options
  start_from_beginning false
</source>
```

Encountered below error.
It seems LTSV parsed result record's keys are symbol, not string.
So, set symbolize_keys => false, for ltsv parse option.


> 2017-11-01 09:30:11 +0900 [warn]: parser error in target_topics01/1 error="value must be string: " value="method:GET\turi:/ranking?pageSize=10\tprotocol:HTTP/1.1\tstatus:200\tsize:22573\treqtime:0.116\tlanguage:-\tsession:-\tscheme:http\thostname:test-api-dev\ttime:2017-11-01T09:19:28+09:00" offset=637339
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.35/lib/fluent/parser.rb:82:in `parse'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-kafka-0.5.5/lib/fluent/plugin/in_kafka_group.rb:168:in `block (2 levels) in run'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-kafka-0.5.5/lib/fluent/plugin/in_kafka_group.rb:163:in `each'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-kafka-0.5.5/lib/fluent/plugin/in_kafka_group.rb:163:in `block in run'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/consumer.rb:251:in `block (3 levels) in each_batch'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/instrumenter.rb:21:in `call'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/instrumenter.rb:21:in `instrument'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/instrumenter.rb:33:in `instrument'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/consumer.rb:241:in `block (2 levels) in each_batch'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/consumer.rb:239:in `each'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/consumer.rb:239:in `block in each_batch'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/consumer.rb:282:in `consumer_loop'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-kafka-0.3.17/lib/kafka/consumer.rb:236:in `each_batch'
>   2017-11-01 09:30:11 +0900 [debug]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-kafka-0.5.5/lib/fluent/plugin/in_kafka_group.rb:157:in `run'

