### PR TITLE
Relax ruby-kafka version. fix #163

### DIFF
--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
   gem.add_dependency 'ltsv'
-  gem.add_dependency 'ruby-kafka', '~> 0.4.1'
+  gem.add_dependency 'ruby-kafka', '>= 0.4.1', '< 1.0.0'
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"
 end


### PR DESCRIPTION
I hope ruby-kafka doesn't break API without announcement.