### PR TITLE
removing ternary for seed_brokers, result is as reqd. on no match split

### DIFF
--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -115,7 +115,7 @@ DESC
     if @zookeeper
       require 'zookeeper'
     else
-      @seed_brokers = @brokers.match(",").nil? ? [@brokers] : @brokers.split(",")
+      @seed_brokers = @brokers.split(",")
       log.info "brokers has been set directly: #{@seed_brokers}"
     end
 

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -141,7 +141,7 @@ DESC
     if @zookeeper
       require 'zookeeper'
     else
-      @seed_brokers = @brokers.match(",").nil? ? [@brokers] : @brokers.split(",")
+      @seed_brokers = @brokers.split(",")
       log.info "brokers has been set directly: #{@seed_brokers}"
     end
 


### PR DESCRIPTION
in ruby a split even without split char present will return require list

```
>> "a:4321,b:4321,c:4321".split(",")
=> ["a:4321", "b:4321", "c:4321"]
>> "a:4321".split(",")
=> ["a:4321"]
```
Signed-off-by: AbhishekKr <abhikumar163@gmail.com>