### PR TITLE
Fix TimeParser class name for fluentd_0.14.7 or later.

### DIFF
--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -108,7 +108,13 @@ class Fluent::KafkaInput < Fluent::Input
     @parser_proc = setup_parser
 
     if @use_record_time and @time_format
-      @time_parser = Fluent::TextParser::TimeParser.new(@time_format)
+      require 'fluent/version'
+      major, minor, patch = Fluent::VERSION.split('.').map(&:to_i)
+      if major > 0 || (major == 0 && minor >= 14 && patch >= 7)
+        @time_parser = Fluent::TimeParser.new(@time_format)
+      else
+        @time_parser = Fluent::TextParser::TimeParser.new(@time_format)
+      end
     end
   end
 

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -108,9 +108,7 @@ class Fluent::KafkaInput < Fluent::Input
     @parser_proc = setup_parser
 
     if @use_record_time and @time_format
-      require 'fluent/version'
-      major, minor, patch = Fluent::VERSION.split('.').map(&:to_i)
-      if major > 0 || (major == 0 && minor >= 14 && patch >= 7)
+      if defined?(Fluent::TimeParser)
         @time_parser = Fluent::TimeParser.new(@time_format)
       else
         @time_parser = Fluent::TextParser::TimeParser.new(@time_format)

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -108,9 +108,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
     @fetch_opts[:min_bytes] = @min_bytes if @min_bytes
 
     if @use_record_time and @time_format
-      require 'fluent/version'
-      major, minor, patch = Fluent::VERSION.split('.').map(&:to_i)
-      if major > 0 || (major == 0 && minor >= 14 && patch >= 7)
+      if defined?(Fluent::TimeParser)
         @time_parser = Fluent::TimeParser.new(@time_format)
       else
         @time_parser = Fluent::TextParser::TimeParser.new(@time_format)

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -108,7 +108,13 @@ class Fluent::KafkaGroupInput < Fluent::Input
     @fetch_opts[:min_bytes] = @min_bytes if @min_bytes
 
     if @use_record_time and @time_format
-      @time_parser = Fluent::TextParser::TimeParser.new(@time_format)
+      require 'fluent/version'
+      major, minor, patch = Fluent::VERSION.split('.').map(&:to_i)
+      if major > 0 || (major == 0 && minor >= 14 && patch >= 7)
+        @time_parser = Fluent::TimeParser.new(@time_format)
+      else
+        @time_parser = Fluent::TextParser::TimeParser.new(@time_format)
+      end
     end
   end
 


### PR DESCRIPTION
When I used this plugin in version v3.1.1(Fluentd v1.0.2), below error occured in process starting process.

```td-agent.conf
<source>
   @type kafka_group

  brokers              kafka01:9092,kafka02:9092,kafka03:9092,
  consumer_group       test_consumer01
  topics               target_topics01
  format               ltsv
  add_prefix           kafka
  use_record_time      true
  time_format          %Y-%m-%dT%H:%M:%S%:z

  # ruby-kafka consumer options
  start_from_beginning false
</source>
```

```
2018-02-28 17:26:49 +0900 [error]: unexpected error error_class=NameError error="uninitialized constant Fluent::TextParser\nDid you mean?  Fluent::TimeParser"
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kafka-0.6.6/lib/fluent/plugin/in_kafka_group.rb:111:in `configure'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/plugin.rb:164:in `configure'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/root_agent.rb:282:in `add_source'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/root_agent.rb:122:in `block in configure'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/root_agent.rb:118:in `each'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/root_agent.rb:118:in `configure'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/engine.rb:131:in `configure'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/engine.rb:96:in `run_configure'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/supervisor.rb:770:in `run_configure'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/supervisor.rb:522:in `block in run_worker'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/supervisor.rb:699:in `main_process'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/supervisor.rb:518:in `run_worker'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/lib/fluent/command/fluentd.rb:316:in `<top (required)>'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.0.2/bin/fluentd:8:in `<top (required)>'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/bin/fluentd:22:in `load'
  2018-02-28 17:26:49 +0900 [error]: /opt/td-agent/embedded/bin/fluentd:22:in `<top (required)>'
  2018-02-28 17:26:49 +0900 [error]: /usr/sbin/td-agent:7:in `load'
  2018-02-28 17:26:49 +0900 [error]: /usr/sbin/td-agent:7:in `<main>'
```

Error occured because TimeParser class name was switched newer fluentd version.
I confirmed past version sources, results are blow.
So add switching class name logic by fluentd version.

- fluentd 1.0.0 or later, Fluent::TimeParser.
  - 1.1.0
    - https://github.com/fluent/fluentd/blob/v1.1.0/lib/fluent/time.rb#L183
  - 1.0.0
    - https://github.com/fluent/fluentd/blob/v1.0.0/lib/fluent/time.rb#L183
- fluentd 0.14.7 or later, Fluent::TimeParser.
  - 0.14.25
    - https://github.com/fluent/fluentd/blob/v0.14.25/lib/fluent/time.rb#L183
  - 0.14.7
    - https://github.com/fluent/fluentd/blob/v0.14.7/lib/fluent/time.rb#L177
- fluentd 0.14.0 to 0.14.6, Fluent::TextParser::TimeParser.
  - 0.14.6
    - https://github.com/fluent/fluentd/blob/v0.14.6/lib/fluent/parser.rb#L22
    - https://github.com/fluent/fluentd/blob/v0.14.6/lib/fluent/compat/parser.rb#L119
    - https://github.com/fluent/fluentd/blob/v0.14.6/lib/fluent/plugin/parser.rb#L55
  - 0.14.0
    - https://github.com/fluent/fluentd/blob/v0.14.0/lib/fluent/parser.rb#L22
    - https://github.com/fluent/fluentd/blob/v0.14.0/lib/fluent/compat/parser.rb#L118
    - https://github.com/fluent/fluentd/blob/v0.14.0/lib/fluent/plugin/parser.rb#L55
- fluentd 0.12.X, Fluent::TextParser::TimeParser.
  - 0.12.42
    - https://github.com/fluent/fluentd/blob/v0.12.42/lib/fluent/parser.rb#L66
  - 0.12.0
    - https://github.com/fluent/fluentd/blob/v0.12.0/lib/fluent/parser.rb#L53
- fluentd 0.10.58 or later , Fluent::TextParser::TimeParser.
  - 0.10.62
    - https://github.com/fluent/fluentd/blob/v0.10.62/lib/fluent/parser.rb#L54
  - 0.10.58
    - https://github.com/fluent/fluentd/blob/v0.10.58/lib/fluent/parser.rb#L54
  - From https://rubygems.org/gems/fluent-plugin-kafka/versions/0.6.6, fluentd < 2, >= 0.10.58
