### PR TITLE
Fix warning log condition.

### DIFF
--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -106,11 +106,11 @@ DESC
       @formatter_proc = setup_formatter(formatter_conf)
 
       if @default_topic.nil?
-        if @chunk_keys.include?('topic') && !@chunk_keys.include?('tag')
+        if @chunk_keys.include?('topic') && !@chunk_key_tag
           log.warn "Use 'topic' field of event record for topic but no fallback. Recommend to set default_topic or set 'tag' in buffer chunk keys like <buffer topic,tag>"
         end
       else
-        if @chunk_keys.include?('tag')
+        if @chunk_key_tag
           log.warn "default_topic is set. Fluentd's event tag is not used for topic"
         end
       end


### PR DESCRIPTION
When I used this plugin in version v3.1.1(Fluentd v1.0.2), warning log printed in process starting process.

```td-agent.conf
<match **>
  @id                         output_log_to_kafka
  @type                       kafka2
  @log_level                  warn
  brokers                     kafka01:9092,kafka02:9092,kafka03:9092,
  # topic_key = topic default, configure for clarification.
  topic_key                   topic
  exclude_topic_key           true

  <buffer topic,tag>
    @type                       file
    path                        "/var/log/td-agent/buffer/output_log_to_kafka.*.log"
    flush_interval              2s
    flush_thread_interval       2s
    flush_thread_burst_interval 1s
    retry_forever               true
    retry_max_interval          300s
    chunk_limit_size            16m
    queue_limit_length          100
  </buffer>
</match>
```

```
2018-02-28 16:58:10 +0900 [warn]: [output_log_to_kafka] Use 'topic' field of event record for topic but no fallback. Recommend to set default_topic or set 'tag' in buffer chunk keys like <buffer topic,tag>
```

Warning occured because at Fluent::Plugin::Output class, 'tag' deleted from  @chunk_keys and set @chunk_key_tag.
  - https://github.com/fluent/fluentd/blob/v1.0.0/lib/fluent/plugin/output.rb#L280
  - https://github.com/fluent/fluentd/blob/v1.1.0/lib/fluent/plugin/output.rb#L280

So fixed warning condition.
