### PR TITLE
Add initialize @seed_brokers in out_kafka2 plugin.

### DIFF
--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -101,7 +101,8 @@ DESC
       super
 
       if @brokers.size > 0
-        log.info "brokers has been set: #{@brokers}"
+        @seed_brokers = @brokers
+        log.info "brokers has been set: #{@seed_brokers}"
       else
         raise Fluent::Config, 'No brokers specified. Need one broker at least.'
       end


### PR DESCRIPTION
By https://github.com/fluent/fluent-plugin-kafka/pull/168, kafka client's seed_brokers parameter switched to @seed_brokers.

To format with other plugin's parameter name, add initialization @seed_brokers from brokers.