### PR TITLE
pickup ssl_endpoint from zookeeper node

### DIFF
--- a/lib/fluent/plugin/kafka_plugin_util.rb
+++ b/lib/fluent/plugin/kafka_plugin_util.rb
@@ -22,6 +22,12 @@ module Fluent
           File.read(path)
         end
       end
+
+      def pickup_ssl_endpoint(node)
+        ssl_endpoint = node['endpoints'].find {|e| e.start_with?('SSL')}
+        raise 'no SSL endpoint found on Zookeeper' unless ssl_endpoint
+        return [URI.parse(ssl_endpoint).host, URI.parse(ssl_endpoint).port].join(':')
+      end
     end
 
     module SaslSettings

--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -90,7 +90,11 @@ DESC
       z = Zookeeper.new(@zookeeper)
       z.get_children(:path => @zookeeper_path)[:children].each do |id|
         broker = Yajl.load(z.get(:path => @zookeeper_path + "/#{id}")[:data])
-        @seed_brokers.push("#{broker['host']}:#{broker['port']}")
+        if @ssl_client_cert
+          @seed_brokers.push(pickup_ssl_endpoint(broker))
+        else
+          @seed_brokers.push("#{broker['host']}:#{broker['port']}")
+        end
       end
       z.close
       log.info "brokers has been refreshed via Zookeeper: #{@seed_brokers}"

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -111,7 +111,11 @@ DESC
       z = Zookeeper.new(@zookeeper)
       z.get_children(:path => @zookeeper_path)[:children].each do |id|
         broker = Yajl.load(z.get(:path => @zookeeper_path + "/#{id}")[:data])
-        @seed_brokers.push("#{broker['host']}:#{broker['port']}")
+        if @ssl_client_cert
+          @seed_brokers.push(pickup_ssl_endpoint(broker))
+        else
+          @seed_brokers.push("#{broker['host']}:#{broker['port']}")
+        end
       end
       z.close
       log.info "brokers has been refreshed via Zookeeper: #{@seed_brokers}"


### PR DESCRIPTION
Hi,

When certificate is specified in configuration, I would like to extract endpoint which is SSL from endpoints obtained from Zookeeper.

The version of kafka used for check is 1.0.0.

For example, when I set `PLAINTEXT: //192.0.2.11: 9092, SSL: //192.0.2.11: 9093` to `ADVERTISED_LISTENERS`. Broker information which can be retrieved from `zookeeper:///brokers/ids/1001` is as follows.

```
{
  "listener_security_protocol_map": {
    "PLAINTEXT": "PLAINTEXT",
    "SSL": "SSL"
  },
  "endpoints": [
    "PLAINTEXT://192.0.2.11:9092",
    "SSL://192.0.2.11:9093"
  ],
  "jmx_port": -1,
  "host": "192.0.2.11",
  "timestamp": "1526455616183",
  "port": 9092,
  "version": 4
}
```