### PR TITLE
out_kafka2: fix to include event_emitter helper

### DIFF
--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -8,7 +8,7 @@ module Fluent::Plugin
   class Fluent::Kafka2Output < Output
     Fluent::Plugin.register_output('kafka2', self)
 
-    helpers :inject, :formatter
+    helpers :inject, :formatter, :event_emitter
 
     config_param :brokers, :array, :value_type => :string, :default => ['localhost:9092'],
                  :desc => <<-DESC


### PR DESCRIPTION
https://github.com/fluent/fluent-plugin-kafka/blob/master/lib/fluent/plugin/out_kafka2.rb#L132-L140

To use `router.emit()` with the v1 API output plugin, it must include `event_emitter` helper.