### PR TITLE
add parameter for exception ignore in kafka2

### DIFF
--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -234,7 +234,7 @@ DESC
       # For safety, refresh client and its producers
       refresh_client(false)
       # raise UnrecoverableError for backup ignored exception chunk
-      raise Fluent::UnrecoverableError if exception_backup
+      raise Fluent::UnrecoverableError if ignore && exception_backup
       # Raise exception to retry sendind messages
       raise e unless ignore
     ensure

--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -221,12 +221,7 @@ DESC
         end
       end
     rescue Exception => e
-      ignore = false
-      if @ignore_exceptions && !@ignore_exceptions.empty?
-        ignore_exceptions.each { | ignore_exception |
-          ignore = true if e.class.name == ignore_exception
-        }
-      end
+      ignore = @ignore_exceptions.include?(e.class.name)
 
       log.warn "Send exception occurred: #{e}"
       log.warn "Exception Backtrace : #{e.backtrace.join("\n")}"


### PR DESCRIPTION
hello, 
for using in output kafka2, I made it to skip ruby-kafka exception. (like skip Kafka::MessageSizeTooLarge)
and add some parameter to backup what chunks make exception occur.

I'm not used to ruby, so give me some feedbacks ^^;

thanks