### PR TITLE
Fix mismatch between config param and reference of message_key_key.

### DIFF
--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -198,7 +198,7 @@ DESC
             record.delete(@topic_key) if @exclude_topic_key
             partition_key = (@exclude_partition_key ? record.delete(@partition_key_key) : record[@partition_key_key]) || @default_partition_key
             partition = (@exclude_partition ? record.delete(@partition_key) : record[@partition_key]) || @default_partition
-            message_key = (@exclude_message_key ? record.delete(@message_key) : record[@message_key]) || @default_message_key
+            message_key = (@exclude_message_key ? record.delete(@message_key_key) : record[@message_key_key]) || @default_message_key
 
             record_buf = @formatter_proc.call(tag, time, record)
           rescue StandardError => e


### PR DESCRIPTION
Setting message key by message_key_key in config file does not work due to mismatch between the definition and the reference in out_kafka2.