### PR TITLE
Be tunable fetcher_max_queue_size for kafka_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Consume events by kafka consumer group features..
       min_bytes               (integer) :default => nil (Use default of ruby-kafka)
       offset_commit_interval  (integer) :default => nil (Use default of ruby-kafka)
       offset_commit_threshold (integer) :default => nil (Use default of ruby-kafka)
+      fetcher_max_queue_size  (integer) :default => nil (Use default of ruby-kafka)
       start_from_beginning    (bool)    :default => true
     </source>
 

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -47,6 +47,8 @@ class Fluent::KafkaGroupInput < Fluent::Input
                :desc => "The interval between offset commits, in seconds"
   config_param :offset_commit_threshold, :integer, :default => nil,
                :desc => "The number of messages that can be processed before their offsets are committed"
+  config_param :fetcher_max_queue_size, :integer, :default => nil,
+               :desc => "The number of fetched messages per partition that are queued in fetcher queue"
   config_param :start_from_beginning, :bool, :default => true,
                :desc => "Whether to start from the beginning of the topic or just subscribe to new messages being produced"
 
@@ -107,6 +109,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
     @consumer_opts[:session_timeout] = @session_timeout if @session_timeout
     @consumer_opts[:offset_commit_interval] = @offset_commit_interval if @offset_commit_interval
     @consumer_opts[:offset_commit_threshold] = @offset_commit_threshold if @offset_commit_threshold
+    @consumer_opts[:fetcher_max_queue_size] = @fetcher_max_queue_size if @fetcher_max_queue_size
 
     @fetch_opts = {}
     @fetch_opts[:max_wait_time] = @max_wait_time if @max_wait_time


### PR DESCRIPTION
### Purpose 

-  Be tunable fetcher_max_queue_size because of tuning fluentd's max process memory size.

### Why?

- Now, ruby-kafka's Fetcher holds fetched batch messages in memory.
  - https://github.com/zendesk/ruby-kafka/blob/v0.6.8/lib/kafka/fetcher.rb#L13
  - (default 100) https://github.com/zendesk/ruby-kafka/blob/v0.6.8/lib/kafka/client.rb#L291
- But, Fetcher's message means "Batched message fetched from all partisions what be assined to consumer.".
  - So, Fetcher's message size is estimated blow.
    - (One fetch result from partition , Max max_bytes=1MB) * (Num of Assined Partition) * fetcher_max_queue_size(100) * Compression Rate
      - Max 500MB over per partition.
    - Therefore, in environment what has many partitions, fluentd process's memory size has become very large.
      - 5GB or over.
- So, if fetcher_max_queue_size is tunable, more useful for tuning fluentd.
