### PR TITLE
 Adding support to not use SSL when using SASL on "in" plugin...

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,25 @@ If you want to use zookeeper related parameters, you also need to install zookee
 
 Set path to SSL related files. See [Encryption and Authentication using SSL](https://github.com/zendesk/ruby-kafka#encryption-and-authentication-using-ssl) for more detail.
 
-#### SASL authentication
+#### SASL authentication 
+
+##### with GSSAPI
 
 - principal
 - keytab
 
-Set principal and path to keytab for SASL/GSSAPI authentication. See [Authentication using SASL](https://github.com/zendesk/ruby-kafka#authentication-using-sasl) for more details.
+Set principal and path to keytab for SASL/GSSAPI authentication. 
+See [Authentication using SASL](https://github.com/zendesk/ruby-kafka#authentication-using-sasl) for more details.
+
+##### with Plain/SCRAM
+
+- username
+- password
+- scram_mechanism
+- sasl_over_ssl
+
+Set username, password, scram_mechanism and sasl_over_ssl for SASL/Plain or Scram authentication. 
+See [Authentication using SASL](https://github.com/zendesk/ruby-kafka#authentication-using-sasl) for more details.
 
 ### Input plugin (@type 'kafka')
 

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -20,6 +20,8 @@ class Fluent::KafkaInput < Fluent::Input
   config_param :topics, :string, :default => nil,
                :desc => "Listening topics(separate with comma',')"
   config_param :client_id, :string, :default => 'kafka'
+  config_param :sasl_over_ssl, :bool, :default => true,
+               :desc => "Set to false to prevent SSL strict mode when using SASL authentication"
   config_param :partition, :integer, :default => 0,
                :desc => "Listening partition"
   config_param :offset, :integer, :default => -1,
@@ -177,7 +179,7 @@ class Fluent::KafkaInput < Fluent::Input
       @kafka = Kafka.new(seed_brokers: @brokers, client_id: @client_id, logger: log, ssl_ca_cert: read_ssl_file(@ssl_ca_cert),
                          ssl_client_cert: read_ssl_file(@ssl_client_cert), ssl_client_cert_key: read_ssl_file(@ssl_client_cert_key),
                          ssl_ca_certs_from_system: @ssl_ca_certs_from_system, sasl_scram_username: @username, sasl_scram_password: @password,
-                         sasl_scram_mechanism: @scram_mechanism)
+                         sasl_scram_mechanism: @scram_mechanism, sasl_over_ssl: @sasl_over_ssl)
     elsif @username != nil && @password != nil
       @kafka = Kafka.new(seed_brokers: @brokers, client_id: @client_id, logger: log, ssl_ca_cert: read_ssl_file(@ssl_ca_cert),
                          ssl_client_cert: read_ssl_file(@ssl_client_cert), ssl_client_cert_key: read_ssl_file(@ssl_client_cert_key),

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -12,6 +12,8 @@ class Fluent::KafkaGroupInput < Fluent::Input
   config_param :topics, :string,
                :desc => "Listening topics(separate with comma',')."
   config_param :client_id, :string, :default => 'kafka'
+  config_param :sasl_over_ssl, :bool, :default => true,
+               :desc => "Set to false to prevent SSL strict mode when using SASL authentication"
   config_param :format, :string, :default => 'json',
                :desc => "Supported format: (json|text|ltsv|msgpack)"
   config_param :message_key, :string, :default => 'message',
@@ -153,7 +155,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
       @kafka = Kafka.new(seed_brokers: @brokers, client_id: @client_id, logger: log, ssl_ca_cert: read_ssl_file(@ssl_ca_cert),
                          ssl_client_cert: read_ssl_file(@ssl_client_cert), ssl_client_cert_key: read_ssl_file(@ssl_client_cert_key),
                          ssl_ca_certs_from_system: @ssl_ca_certs_from_system, sasl_scram_username: @username, sasl_scram_password: @password,
-                         sasl_scram_mechanism: @scram_mechanism)
+                         sasl_scram_mechanism: @scram_mechanism, sasl_over_ssl: @sasl_over_ssl)
     elsif @username != nil && @password != nil
       @kafka = Kafka.new(seed_brokers: @brokers, client_id: @client_id, logger: log, ssl_ca_cert: read_ssl_file(@ssl_ca_cert),
                          ssl_client_cert: read_ssl_file(@ssl_client_cert), ssl_client_cert_key: read_ssl_file(@ssl_client_cert_key),


### PR DESCRIPTION
like "out" plugin commit 8ea31d00d4d8ba0598171e7f6dbb4be9e05724b2, this pull request add support to not use SSL when using SASL to "in" plugin....