### PR TITLE
fix: convert record's time to string before attempting to parse it

### DIFF
--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -226,7 +226,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
               record = @parser_proc.call(msg)
               if @use_record_time
                 if @time_format
-                  record_time = @time_parser.parse(record['time'])
+                  record_time = @time_parser.parse(record['time'].to_s)
                 else
                   record_time = record['time']
                 end


### PR DESCRIPTION
Greetings,

While working with Fluentbit Kafka output and this plugin input, I noticed that I could not use the `use_record_time` option as the time was written as a unix timestamp with added milliseconds because it was sent as a number.

This change simply cast the `record['time']` field before attempting to parse it, allowing us to have something like:

```
<source>
  @type kafka_group
  brokers XXX
  consumer_group XXX
  topics XXX
  format msgpack
  use_record_time true
  time_format "%s.%L" 
</source>
```

Let me know if this change is useful and if it was the correct way to do this, or it was an issue on my end.