### PR TITLE
`chunk.metadata.variables` could be nil

### DIFF
--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -230,7 +230,7 @@ DESC
 
     def write(chunk)
       tag = chunk.metadata.tag
-      topic = chunk.metadata.variables[@topic_key_sym] || @default_topic || tag
+      topic = (chunk.metadata.variables && chunk.metadata.variables[@topic_key_sym]) || @default_topic || tag
 
       handlers = []
       record_buf = nil


### PR DESCRIPTION
Without this patch, No method error could be raised here.

@repeatedly Could you review this?