### PR TITLE
Fix chunk.metadata.variables can be nil for kafka2

### DIFF
--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -198,7 +198,7 @@ DESC
     # TODO: optimize write performance
     def write(chunk)
       tag = chunk.metadata.tag
-      topic = chunk.metadata.variables[@topic_key_sym] || @default_topic || tag
+      topic =  (chunk.metadata.variables && chunk.metadata.variables[@topic_key_sym]) || @default_topic || tag
 
       messages = 0
       record_buf = nil


### PR DESCRIPTION
`chunk.metadata.varialbes` can be and defaults to `nil`.
Need to handle that case.

This was already fixed for rdkafka2.

Signed-off-by: Kevin S Kirkup <kevin.kirkup@pureport.com>