### PR TITLE
Enable defining headers for kafka2 and rdkafka2 output

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The format is like key1:value1,key2:value2. For example:
 
 You may set header values based on a value of a fluentd record field. For example, imagine a fluentd record like:
 
-    {"source": { "ip": "127.0.0.1 }, "payload": "hello world" }
+    {"source": { "ip": "127.0.0.1" }, "payload": "hello world" }
 
 And the following fluentd config:
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ This plugin is for fluentd v1.0 or later. This will be `out_kafka` plugin in the
       exclude_topic_key     (bool)   :default => false
       exclude_partition_key (bool)   :default => false
       get_kafka_client_log  (bool)   :default => false
+      headers               (hash)   :default => {}
+      headers_from_record   (hash)   :default => {}
       use_default_for_unknown_topic (bool) :default => false
 
       <format>
@@ -244,6 +246,31 @@ If key name `partition_key_key` exists in a message, this plugin set the value o
 |Set| Exists | Messages which have partition_key_key record are assigned to the specific partition with partition_key_key, others are assigned to the specific partition with default_parition_key |
 
 If key name `message_key_key` exists in a message, this plugin publishes the value of message_key_key to kafka and can be read by consumers. Same message key will be assigned to all messages by setting `default_message_key` in config file. If message_key_key exists and if partition_key_key is not set explicitly, messsage_key_key will be used for partitioning.
+
+#### Headers
+It is possible to set headers on Kafka messages. The format is like key1:value1,key2:value2
+
+    <match app.**>
+      @type kafka2
+      [...]
+      headers some_header_name:some_header_value
+    <match>
+
+You may set header values based on a value of a fluentd record field. For example, imagine a fluentd record like:
+
+    {"source": { "ip": "127.0.0.1 }, "payload": "hello world" }
+
+And the following fluentd config:
+
+    <match app.**>
+      @type kafka2
+      [...]
+      headers_from_record source_ip:$.source.ip
+    <match>
+
+The Kafka message will have a header of source_ip=12.7.0.0.1.
+
+The configuration format is jsonpath. It is descibed in https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-record_accessor
 
 ### Buffered output plugin
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ If key name `partition_key_key` exists in a message, this plugin set the value o
 If key name `message_key_key` exists in a message, this plugin publishes the value of message_key_key to kafka and can be read by consumers. Same message key will be assigned to all messages by setting `default_message_key` in config file. If message_key_key exists and if partition_key_key is not set explicitly, messsage_key_key will be used for partitioning.
 
 #### Headers
-It is possible to set headers on Kafka messages. The format is like key1:value1,key2:value2
+It is possible to set headers on Kafka messages. This only works for kafka2 and rdkafka2 output plugin.
+
+The format is like key1:value1,key2:value2. For example:
 
     <match app.**>
       @type kafka2
@@ -371,6 +373,8 @@ You need to install rdkafka gem.
       default_message_key   (string) :default => nil
       exclude_topic_key     (bool) :default => false
       exclude_partition_key (bool) :default => false
+      headers               (hash)   :default => {}
+      headers_from_record   (hash)   :default => {}
 
       <format>
         @type (json|ltsv|msgpack|attr:<record name>|<formatter name>) :default => json

--- a/lib/fluent/plugin/kafka_producer_ext.rb
+++ b/lib/fluent/plugin/kafka_producer_ext.rb
@@ -99,13 +99,13 @@ module Kafka
       @pending_message_queue = PendingMessageQueue.new
     end
 
-    def produce(value, key: nil, partition: nil, partition_key: nil)
+    def produce(value, key: nil, partition: nil, partition_key: nil, headers: EMPTY_HEADER)
       create_time = Time.now
 
       message = PendingMessage.new(
         value: value,
         key: key,
-        headers: EMPTY_HEADER,
+        headers: headers,
         topic: @topic,
         partition: partition,
         partition_key: partition_key,

--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -216,7 +216,6 @@ DESC
             message_key = (@exclude_message_key ? record.delete(@message_key_key) : record[@message_key_key]) || @default_message_key
 
             headers = @headers
-
             @headers_from_record.each do |key, value|
               headers[key] = record_accessor_create(value).call(record)
             end


### PR DESCRIPTION
I'd like to be able to define headers on a Kafka message based on the content of a fluentd record.

This is due to the Splunk Kafka Connect plugin using Kafka headers to populate some metadata about an event in Splunk ([source](https://github.com/splunk/kafka-connect-splunk#headers-parameters)).

---

I've raised this PR to see if the maintainer is interested in the contribution. No offence taken if not, I'd be wary about accepting new code without any automated tests.