### PR TITLE
Support specifying CreateTime from a record field

### DIFF
--- a/lib/fluent/plugin/kafka_producer_ext.rb
+++ b/lib/fluent/plugin/kafka_producer_ext.rb
@@ -12,8 +12,8 @@ module Kafka
   EMPTY_HEADER = {}
 
   class Producer
-    def produce_for_buffered(value, key: nil, topic:, partition: nil, partition_key: nil)
-      create_time = Time.now
+    def produce_for_buffered(value, key: nil, topic:, partition: nil, partition_key: nil, create_time: nil)
+      create_time ||= Time.now
 
       message = PendingMessage.new(
         value: value,
@@ -99,8 +99,8 @@ module Kafka
       @pending_message_queue = PendingMessageQueue.new
     end
 
-    def produce(value, key: nil, partition: nil, partition_key: nil)
-      create_time = Time.now
+    def produce(value, key: nil, partition: nil, partition_key: nil, create_time: nil)
+      create_time ||= Time.now
 
       message = PendingMessage.new(
         value: value,

--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -20,6 +20,7 @@ DESC
                  :desc => "Default output topic when record doesn't have topic field"
     config_param :message_key_key, :string, :default => 'message_key', :desc => "Field for kafka message key"
     config_param :default_message_key, :string, :default => nil
+    config_param :create_time_key, :string, :default => nil, :desc => "Field for CreateTime"
     config_param :partition_key_key, :string, :default => 'partition_key', :desc => "Field for kafka partition key"
     config_param :default_partition_key, :string, :default => nil
     config_param :partition_key, :string, :default => 'partition', :desc => "Field for kafka partition"
@@ -229,7 +230,9 @@ DESC
           log.trace { "message will send to #{topic} with partition_key: #{partition_key}, partition: #{partition}, message_key: #{message_key} and value: #{record_buf}." }
           messages += 1
 
-          producer.produce(record_buf, key: message_key, partition_key: partition_key, partition: partition)
+          create_time = @create_time_key != nil ? record[@create_time_key]: nil
+
+          producer.produce(record_buf, key: message_key, partition_key: partition_key, partition: partition, create_time: create_time)
         }
 
         if messages > 0

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -22,6 +22,7 @@ DESC
   config_param :default_topic, :string, :default => nil, :desc => "Default output topic when record doesn't have topic field"
   config_param :message_key_key, :string, :default => 'message_key', :desc => "Field for kafka message key"
   config_param :default_message_key, :string, :default => nil
+  config_param :create_time_key, :string, :default => nil, :desc => "Field for CreateTime"
   config_param :partition_key_key, :string, :default => 'partition_key', :desc => "Field for kafka partition key"
   config_param :default_partition_key, :string, :default => nil
   config_param :partition_key, :string, :default => 'partition', :desc => "Field for kafka partition"
@@ -339,7 +340,10 @@ DESC
         end
         log.trace { "message will send to #{topic} with partition_key: #{partition_key}, partition: #{partition}, message_key: #{message_key} and value: #{record_buf}." }
         messages += 1
-        producer.produce_for_buffered(record_buf, topic: topic, key: message_key, partition_key: partition_key, partition: partition)
+
+        create_time = @create_time_key != nil ? record[@create_time_key]: nil
+
+        producer.produce_for_buffered(record_buf, topic: topic, key: message_key, partition_key: partition_key, partition: partition, create_time: create_time)
         messages_bytes += record_buf_bytes
 
         records_by_topic[topic] += 1


### PR DESCRIPTION
Hello. I ran into a use case where I need to set CreateTIme from a record field. I added a config_param `create_time_key` so that users can specify a field containing the time data they want to use as CreateTime. Please consider this PR, and let me know if you approve of it!