### PR TITLE
Add use_event_time to use fluentd event time for CreateTime. fix #273

### DIFF
--- a/lib/fluent/plugin/kafka_producer_ext.rb
+++ b/lib/fluent/plugin/kafka_producer_ext.rb
@@ -12,9 +12,7 @@ module Kafka
   EMPTY_HEADER = {}
 
   class Producer
-    def produce_for_buffered(value, key: nil, topic:, partition: nil, partition_key: nil)
-      create_time = Time.now
-
+    def produce_for_buffered(value, key: nil, topic:, partition: nil, partition_key: nil, create_time: Time.now)
       message = PendingMessage.new(
         value: value,
         key: key,
@@ -99,9 +97,7 @@ module Kafka
       @pending_message_queue = PendingMessageQueue.new
     end
 
-    def produce(value, key: nil, partition: nil, partition_key: nil)
-      create_time = Time.now
-
+    def produce(value, key: nil, partition: nil, partition_key: nil, create_time: Time.now)
       message = PendingMessage.new(
         value: value,
         key: key,

--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -39,6 +39,7 @@ DESC
                  :desc => 'Set true to remove partition key from data'
     config_param :exclude_topic_key, :bool, :default => false,
                  :desc => 'Set true to remove topic name key from data'
+    config_param :use_event_time, :bool, :default => false, :desc => 'Use fluentd event time for kafka create_time'
 
     config_param :get_kafka_client_log, :bool, :default => false
 
@@ -229,7 +230,8 @@ DESC
           log.trace { "message will send to #{topic} with partition_key: #{partition_key}, partition: #{partition}, message_key: #{message_key} and value: #{record_buf}." }
           messages += 1
 
-          producer.produce(record_buf, key: message_key, partition_key: partition_key, partition: partition)
+          producer.produce(record_buf, key: message_key, partition_key: partition_key, partition: partition,
+                           create_time: @use_event_time ? Time.at(time) : Time.now)
         }
 
         if messages > 0

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -46,14 +46,15 @@ DESC
                :desc => <<-DESC
 Set true to remove partition from data
 DESC
-   config_param :exclude_message_key, :bool, :default => false,
+  config_param :exclude_message_key, :bool, :default => false,
                :desc => <<-DESC
 Set true to remove message key from data
 DESC
-   config_param :exclude_topic_key, :bool, :default => false,
+  config_param :exclude_topic_key, :bool, :default => false,
                 :desc => <<-DESC
 Set true to remove topic name key from data
 DESC
+  config_param :use_event_time, :bool, :default => false, :desc => 'Use fluentd event time for kafka create_time'
 
   config_param :kafka_agg_max_bytes, :size, :default => 4*1024  #4k
   config_param :kafka_agg_max_messages, :integer, :default => nil
@@ -339,7 +340,8 @@ DESC
         end
         log.trace { "message will send to #{topic} with partition_key: #{partition_key}, partition: #{partition}, message_key: #{message_key} and value: #{record_buf}." }
         messages += 1
-        producer.produce_for_buffered(record_buf, topic: topic, key: message_key, partition_key: partition_key, partition: partition)
+        producer.produce_for_buffered(record_buf, topic: topic, key: message_key, partition_key: partition_key, partition: partition,
+                                      create_time: @use_event_time ? Time.at(time) : Time.now)
         messages_bytes += record_buf_bytes
 
         records_by_topic[topic] += 1


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

Replacement for https://github.com/fluent/fluent-plugin-kafka/pull/278