### PR TITLE
Add description of time_source in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Consume events by kafka consumer group features..
       add_prefix <tag prefix (Optional)>
       add_suffix <tag suffix (Optional)>
       retry_emit_limit <Wait retry_emit_limit x 1s when BuffereQueueLimitError happens. The default is nil and it means waiting until BufferQueueLimitError is resolved>
-      use_record_time <If true, replace event time with contents of 'time' field of fetched record>
+      use_record_time (Deprecated. Use 'time_source record' instead.) <If true, replace event time with contents of 'time' field of fetched record>
+      time_source <source for message timestamp (now|kafka|record)> :default => now
       time_format <string (Optional when use_record_time is used)>
 
       # ruby-kafka consumer options


### PR DESCRIPTION
Add description of time_source in input plugin. 
I needed kafka timestamp, but there was no description in README.md. But, for the kafka timestamp, the time_source record was already implemented in the code, and it was necessary to explain it.

