### PR TITLE
Add custom time key when time_source is record

### DIFF
--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -39,6 +39,8 @@ class Fluent::KafkaInput < Fluent::Input
                :deprecated => "Use 'time_source record' instead."
   config_param :time_source, :enum, :list => [:now, :kafka, :record], :default => :now,
                :desc => "Source for message timestamp."
+  config_param :record_time_key, :string, :default => 'time',
+               :desc => "Time field when time_source is 'record'"
   config_param :get_kafka_client_log, :bool, :default => false
   config_param :time_format, :string, :default => nil,
                :desc => "Time format to be used to parse 'time' field."
@@ -114,8 +116,10 @@ class Fluent::KafkaInput < Fluent::Input
     @parser_proc = setup_parser
 
     @time_source = :record if @use_record_time
+    @time_key = 'time'
 
     if @time_source == :record and @time_format
+      @time_key = @record_time_key if @record_time_key
       if defined?(Fluent::TimeParser)
         @time_parser = Fluent::TimeParser.new(@time_format)
       else
@@ -292,9 +296,9 @@ class Fluent::KafkaInput < Fluent::Input
             record_time = Fluent::Engine.now
           when :record
             if @time_format
-              record_time = @time_parser.parse(record['time'])
+              record_time = @time_parser.parse(record[@time_key])
             else
-              record_time = record['time']
+              record_time = record[@time_key]
             end
           else
             $log.fatal "BUG: invalid time_source: #{@time_source}"

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -116,10 +116,8 @@ class Fluent::KafkaInput < Fluent::Input
     @parser_proc = setup_parser
 
     @time_source = :record if @use_record_time
-    @time_key = 'time'
 
     if @time_source == :record and @time_format
-      @time_key = @record_time_key if @record_time_key
       if defined?(Fluent::TimeParser)
         @time_parser = Fluent::TimeParser.new(@time_format)
       else
@@ -296,9 +294,9 @@ class Fluent::KafkaInput < Fluent::Input
             record_time = Fluent::Engine.now
           when :record
             if @time_format
-              record_time = @time_parser.parse(record[@time_key])
+              record_time = @time_parser.parse(record[@record_time_key])
             else
-              record_time = record[@time_key]
+              record_time = record[@record_time_key]
             end
           else
             $log.fatal "BUG: invalid time_source: #{@time_source}"

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -128,10 +128,8 @@ class Fluent::KafkaGroupInput < Fluent::Input
     @fetch_opts[:min_bytes] = @min_bytes if @min_bytes
 
     @time_source = :record if @use_record_time
-    @time_key = 'time'
 
     if @time_source == :record and @time_format
-      @time_key = @record_time_key if @record_time_key
       if defined?(Fluent::TimeParser)
         @time_parser = Fluent::TimeParser.new(@time_format)
       else
@@ -247,9 +245,9 @@ class Fluent::KafkaGroupInput < Fluent::Input
                 record_time = Fluent::Engine.now
               when :record
                 if @time_format
-                  record_time = @time_parser.parse(record[@time_key].to_s)
+                  record_time = @time_parser.parse(record[@record_time_key].to_s)
                 else
-                  record_time = record[@time_key]
+                  record_time = record[@record_time_key]
                 end
               else
                 log.fatal "BUG: invalid time_source: #{@time_source}"

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -29,6 +29,8 @@ class Fluent::KafkaGroupInput < Fluent::Input
                :deprecated => "Use 'time_source record' instead."
   config_param :time_source, :enum, :list => [:now, :kafka, :record], :default => :now,
                :desc => "Source for message timestamp."
+  config_param :record_time_key, :string, :default => 'time',
+               :desc => "Time field when time_source is 'record'"
   config_param :get_kafka_client_log, :bool, :default => false
   config_param :time_format, :string, :default => nil,
                :desc => "Time format to be used to parse 'time' field."
@@ -126,8 +128,10 @@ class Fluent::KafkaGroupInput < Fluent::Input
     @fetch_opts[:min_bytes] = @min_bytes if @min_bytes
 
     @time_source = :record if @use_record_time
+    @time_key = 'time'
 
     if @time_source == :record and @time_format
+      @time_key = @record_time_key if @record_time_key
       if defined?(Fluent::TimeParser)
         @time_parser = Fluent::TimeParser.new(@time_format)
       else
@@ -243,9 +247,9 @@ class Fluent::KafkaGroupInput < Fluent::Input
                 record_time = Fluent::Engine.now
               when :record
                 if @time_format
-                  record_time = @time_parser.parse(record['time'].to_s)
+                  record_time = @time_parser.parse(record[@time_key].to_s)
                 else
-                  record_time = record['time']
+                  record_time = record[@time_key]
                 end
               else
                 log.fatal "BUG: invalid time_source: #{@time_source}"


### PR DESCRIPTION
When we set time_source to record, we can specify time field instead of fixed value, 'time'.