### PR TITLE
Fix partitioner call in Kafka::Producer due to ruby-kafka change

### DIFF
--- a/lib/fluent/plugin/kafka_producer_ext.rb
+++ b/lib/fluent/plugin/kafka_producer_ext.rb
@@ -250,7 +250,7 @@ module Kafka
 
         begin
           if partition.nil?
-            partition = Partitioner.partition_for_key(partition_count, message)
+            partition = Partitioner.call(partition_count, message)
           end
 
           @buffer.write(


### PR DESCRIPTION
The newest version of ruby-kafka changed the Kafka::Partitioner API from `partition_for_key` to `call`: https://github.com/zendesk/ruby-kafka/commit/8dc495f471312834e477cd16144a32295c6b0a65#diff-0bc0466ba80bcb74058c1e4def09bf41R22