### PR TITLE
Treat empty string in read_ssl_file as nil

### DIFF
--- a/lib/fluent/plugin/kafka_plugin_util.rb
+++ b/lib/fluent/plugin/kafka_plugin_util.rb
@@ -33,7 +33,7 @@ module Fluent
       end
 
       def read_ssl_file(path)
-        return nil if path.nil?
+        return nil if path.presence.nil?
 
         if path.is_a?(Array)
           path.map { |fp| File.read(fp) }


### PR DESCRIPTION
This resolves an issue where trying to dynamically configure SSL and path is empty string instead of nil where it errors like:
```
2020-09-29 14:44:52 +0000 [error]: unexpected error error_class=Errno::ENOENT error="No such file or directory @ rb_sysopen - "
  2020-09-29 14:44:52 +0000 [error]: /usr/local/share/gems/gems/fluent-plugin-kafka-0.13.1/lib/fluent/plugin/kafka_plugin_util.rb:41:in `read'
  2020-09-29 14:44:52 +0000 [error]: /usr/local/share/gems/gems/fluent-plugin-kafka-0.13.1/lib/fluent/plugin/kafka_plugin_util.rb:41:in `read_ssl_file'
```