### PR TITLE
Treat empty string in read_ssl_file as nil

### DIFF
--- a/lib/fluent/plugin/kafka_plugin_util.rb
+++ b/lib/fluent/plugin/kafka_plugin_util.rb
@@ -33,7 +33,7 @@ module Fluent
       end
 
       def read_ssl_file(path)
-        return nil if path.nil?
+        return nil if path.nil? || path.respond_to?(:strip) && path.strip.empty?
 
         if path.is_a?(Array)
           path.map { |fp| File.read(fp) }

--- a/test/plugin/test_kafka_plugin_util.rb
+++ b/test/plugin/test_kafka_plugin_util.rb
@@ -1,0 +1,38 @@
+require 'helper'
+require 'fluent/plugin/kafka_plugin_util'
+
+class File
+    def File::read(path)
+        path
+    end
+end
+
+class KafkaPluginUtilTest < Test::Unit::TestCase
+    
+    def self.config_param(name, type, options)
+    end
+    include Fluent::KafkaPluginUtil::SSLSettings
+
+    def config_param
+    end
+    def setup
+        Fluent::Test.setup
+    end
+
+    def test_read_ssl_file_when_nil
+        assert_equal(nil, read_ssl_file(nil))
+    end
+
+    def test_read_ssl_file_when_empty_string
+        assert_equal(nil, read_ssl_file(""))
+    end
+
+    def test_read_ssl_file_when_non_empty_path
+        assert_equal("path", read_ssl_file("path"))
+    end
+
+    def test_read_ssl_file_when_non_empty_array
+        assert_equal(["a","b"], read_ssl_file(["a","b"]))
+    end
+
+end


### PR DESCRIPTION
Signed-off-by: Jeff Cantrill <jcantril@redhat.com>

This resolves an issue where trying to dynamically configure SSL and path is empty string instead of nil where it errors like:
```
2020-09-29 14:44:52 +0000 [error]: unexpected error error_class=Errno::ENOENT error="No such file or directory @ rb_sysopen - "
  2020-09-29 14:44:52 +0000 [error]: /usr/local/share/gems/gems/fluent-plugin-kafka-0.13.1/lib/fluent/plugin/kafka_plugin_util.rb:41:in `read'
  2020-09-29 14:44:52 +0000 [error]: /usr/local/share/gems/gems/fluent-plugin-kafka-0.13.1/lib/fluent/plugin/kafka_plugin_util.rb:41:in `read_ssl_file'
```
from `ssl_client_cert_key "#{File.exist?('{{ $tlsKey }}') ? '{{ $tlsKey }}' : nil"`