### PR TITLE
Use NumericTimeParser to parse float time

### DIFF
--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -138,6 +138,10 @@ class Fluent::KafkaGroupInput < Fluent::Input
         @time_parser = Fluent::TextParser::TimeParser.new(@time_format)
       end
     end
+
+    if @time_source == :record && defined?(Fluent::NumericTimeParser)
+      @float_numeric_parse = Fluent::NumericTimeParser.new(:float)
+    end
   end
 
   def setup_parser(conf)
@@ -262,10 +266,12 @@ class Fluent::KafkaGroupInput < Fluent::Input
               when :now
                 record_time = Fluent::Engine.now
               when :record
+                record_time = record[@record_time_key]
+
                 if @time_format
-                  record_time = @time_parser.parse(record[@record_time_key].to_s)
-                else
-                  record_time = record[@record_time_key]
+                  record_time = @time_parser.parse(record_time.to_s)
+                elsif record_time.is_a?(Float) && @float_numeric_parse
+                  record_time = @float_numeric_parse.parse(record_time)
                 end
               else
                 log.fatal "BUG: invalid time_source: #{@time_source}"


### PR DESCRIPTION
The [fluentd documentation](https://docs.fluentd.org/configuration/format-section#time-parameters) says:
```
time_type (enum) (optional): parses/formats value according to this type
Default: float (econds from Epoch + nano seconds (e.g.1510544836.154709804))
```
But the `float` type is not supported by default in this library. As a result, an [error raises](https://github.com/fluent/fluentd/blob/v1.11.5/lib/fluent/plugin/output.rb#L828):
```
time must be a Fluent::EventTime (or Integer): Float
```
I suggest using parser [Fluent::NumericTimeParser](https://github.com/fluent/fluentd/blob/v1.11.5/lib/fluent/time.rb#L282) for float times like other [plugins do](https://github.com/fluent/fluentd/blob/v1.11.5/lib/fluent/time.rb#L182).

P.S. Use [time_format "%s.%L"](https://github.com/fluent/fluent-plugin-kafka/pull/238) does not seem very correct to me.