### PR TITLE
Add option to use record as source for the Fluentd event tag

### DIFF
--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -33,6 +33,8 @@ class Fluent::KafkaInput < Fluent::Input
   config_param :add_offset_in_record, :bool, :default => false
   config_param :tag_source, :enum, :list => [:topic, :record], :default => :topic,
                :desc => "Source for the fluentd event tag"
+  config_param :record_tag_key, :string, :default => 'tag',
+               :desc => "Tag field when tag_source is 'record'"
 
   config_param :offset_zookeeper, :string, :default => nil
   config_param :offset_zk_root_node, :string, :default => '/fluent-plugin-kafka'
@@ -228,6 +230,7 @@ class Fluent::KafkaInput < Fluent::Input
         @time_source,
         @record_time_key,
         @tag_source,
+        @record_tag_key,
         opt)
     }
     @topic_watchers.each {|tw|
@@ -252,7 +255,7 @@ class Fluent::KafkaInput < Fluent::Input
   end
 
   class TopicWatcher < Coolio::TimerWatcher
-    def initialize(topic_entry, kafka, interval, parser, add_prefix, add_suffix, offset_manager, router, kafka_message_key, time_source, record_time_key, tag_source, options={})
+    def initialize(topic_entry, kafka, interval, parser, add_prefix, add_suffix, offset_manager, router, kafka_message_key, time_source, record_time_key, tag_source, record_tag_key, options={})
       @topic_entry = topic_entry
       @kafka = kafka
       @callback = method(:consume)
@@ -266,6 +269,7 @@ class Fluent::KafkaInput < Fluent::Input
       @time_source = time_source
       @record_time_key = record_time_key
       @tag_source = tag_source
+      @record_tag_key = record_tag_key
 
       @next_offset = @topic_entry.offset
       if @topic_entry.offset == -1 && offset_manager
@@ -303,7 +307,7 @@ class Fluent::KafkaInput < Fluent::Input
         begin
           record = @parser.call(msg, @topic_entry)
           if @tag_source == :record
-            tag = record["tag"]
+            tag = record[@record_tag_key]
             tag = @add_prefix + "." + tag if @add_prefix
             tag = tag + "." + @add_suffix if @add_suffix
           end

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -248,55 +248,102 @@ class Fluent::KafkaGroupInput < Fluent::Input
     end
   end
 
+  def process_batch_with_record_tag(batch)
+    es = {} 
+    batch.messages.each { |msg|
+      begin
+        record = @parser_proc.call(msg)
+        tag = record[@record_tag_key]
+        tag = @add_prefix + "." + tag if @add_prefix
+        tag = tag + "." + @add_suffix if @add_suffix
+        es[tag] ||= Fluent::MultiEventStream.new
+        case @time_source
+        when :kafka
+          record_time = Fluent::EventTime.from_time(msg.create_time)
+        when :now
+          record_time = Fluent::Engine.now
+        when :record
+          if @time_format
+            record_time = @time_parser.parse(record[@record_time_key].to_s)
+          else
+            record_time = record[@record_time_key]
+          end
+        else
+          log.fatal "BUG: invalid time_source: #{@time_source}"
+        end
+        if @kafka_message_key
+          record[@kafka_message_key] = msg.key
+        end
+        if @add_headers
+          msg.headers.each_pair { |k, v|
+            record[k] = v
+          }
+        end
+        es[tag].add(record_time, record)
+      rescue => e
+        log.warn "parser error in #{batch.topic}/#{batch.partition}", :error => e.to_s, :value => msg.value, :offset => msg.offset
+        log.debug_backtrace
+      end
+    }
+
+    unless es.empty?
+      es.each { |tag,es|
+        emit_events(tag, es)
+      }
+    end
+  end
+
+  def process_batch(batch)
+    es = Fluent::MultiEventStream.new
+    tag = batch.topic
+    tag = @add_prefix + "." + tag if @add_prefix
+    tag = tag + "." + @add_suffix if @add_suffix
+
+    batch.messages.each { |msg|
+      begin
+        record = @parser_proc.call(msg)
+        case @time_source
+        when :kafka
+          record_time = Fluent::EventTime.from_time(msg.create_time)
+        when :now
+          record_time = Fluent::Engine.now
+        when :record
+          if @time_format
+            record_time = @time_parser.parse(record[@record_time_key].to_s)
+          else
+            record_time = record[@record_time_key]
+          end
+        else
+          log.fatal "BUG: invalid time_source: #{@time_source}"
+        end
+        if @kafka_message_key
+          record[@kafka_message_key] = msg.key
+        end
+        if @add_headers
+          msg.headers.each_pair { |k, v|
+            record[k] = v
+          }
+        end
+        es.add(record_time, record)
+      rescue => e
+        log.warn "parser error in #{batch.topic}/#{batch.partition}", :error => e.to_s, :value => msg.value, :offset => msg.offset
+        log.debug_backtrace
+      end
+    }
+
+    unless es.empty?
+      emit_events(tag, es)
+    end
+  end
+
   def run
     while @consumer
       begin
         @consumer.each_batch(@fetch_opts) { |batch|
-          es = {}   
-          batch.messages.each { |msg|
-            begin
-              record = @parser_proc.call(msg)
-              if @tag_source == :record
-                tag = record[@record_tag_key]
-              else 
-                tag = batch.topic
-              end
-              tag = @add_prefix + "." + tag if @add_prefix
-              tag = tag + "." + @add_suffix if @add_suffix
-              es[tag] ||= Fluent::MultiEventStream.new
-              case @time_source
-              when :kafka
-                record_time = Fluent::EventTime.from_time(msg.create_time)
-              when :now
-                record_time = Fluent::Engine.now
-              when :record
-                if @time_format
-                  record_time = @time_parser.parse(record[@record_time_key].to_s)
-                else
-                  record_time = record[@record_time_key]
-                end
-              else
-                log.fatal "BUG: invalid time_source: #{@time_source}"
-              end
-              if @kafka_message_key
-                record[@kafka_message_key] = msg.key
-              end
-              if @add_headers
-                msg.headers.each_pair { |k, v|
-                  record[k] = v
-                }
-              end
-              es[tag].add(record_time, record)
-            rescue => e
-              log.warn "parser error in #{batch.topic}/#{batch.partition}", :error => e.to_s, :value => msg.value, :offset => msg.offset
-              log.debug_backtrace
-            end
-          }
-
-          unless es.empty?
-            es.each { |tag,es|
-              emit_events(tag, es)
-            }
+          if @tag_source == :record
+            process_batch_with_record_tag(batch)
+          else
+            process_batch(batch) 
           end
         }
       rescue ForShutdown

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -38,6 +38,8 @@ class Fluent::KafkaGroupInput < Fluent::Input
                :desc => "Time format to be used to parse 'time' field."
   config_param :tag_source, :enum, :list => [:topic, :record], :default => :topic,
                :desc => "Source for the fluentd event tag"
+  config_param :record_tag_key, :string, :default => 'tag',
+               :desc => "Tag field when tag_source is 'record'"
   config_param :kafka_message_key, :string, :default => nil,
                :desc => "Set kafka's message key to this field"
   config_param :connect_timeout, :integer, :default => nil,
@@ -255,7 +257,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
             begin
               record = @parser_proc.call(msg)
               if @tag_source == :record
-                tag = record["tag"]
+                tag = record[@record_tag_key]
               else 
                 tag = batch.topic
               end


### PR DESCRIPTION
This PR adds the option to set the Fluentd event tag to a record field instead of the topic name only (similar to the existing `time_source` option).

We created this on our side as we have the need to keep the source event tags when we have a Fluentd on a source cluster and another one on a target cluster where a Kafka topic is acting as queue in between.