### PR TITLE
out_kafka: out_kafka_buffered: Support Ruby 3.0.0 keyword arguments interop

### DIFF
--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -215,7 +215,7 @@ DESC
       chain.next
 
       # out_kafka is mainly for testing so don't need the performance unlike out_kafka_buffered.
-      producer = @kafka.producer(@producer_opts)
+      producer = @kafka.producer(**@producer_opts)
 
       es.each do |time, record|
         if @output_include_time

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -239,7 +239,7 @@ DESC
     @producers_mutex.synchronize {
       producer = @producers[Thread.current.object_id]
       unless producer
-        producer = @kafka.producer(@producer_opts)
+        producer = @kafka.producer(**@producer_opts)
         @producers[Thread.current.object_id] = producer
       end
       producer


### PR DESCRIPTION
Ruby 3.0.0 keywords arguments do not permit Hash <-> keyword arguments
interop.
Instead, we should add a double asterisk operator(`**`) for it.

Otherwise, Fluentd which is working with Ruby 3.0.0 complains the following error:

```log
2021-03-17 11:30:35 +0900 [warn]: #0 Send exception occurred: wrong number of arguments (given 1, expected 0)
2021-03-17 11:30:35 +0900 [warn]: #0 Exception Backtrace : /Users/cosmo/GitHub/fluentd/vendor/bundle/ruby/3.0.0/gems/ruby-kafka-1.3.0/lib/kafka/client.rb:261:in `producer'
/Users/cosmo/GitHub/fluentd/vendor/bundle/ruby/3.0.0/gems/fluent-plugin-kafka-0.16.0/lib/fluent/plugin/out_kafka_buffered.rb:242:in `block in get_producer'
/Users/cosmo/GitHub/fluentd/vendor/bundle/ruby/3.0.0/gems/fluent-plugin-kafka-0.16.0/lib/fluent/plugin/out_kafka_buffered.rb:239:in `synchronize'
/Users/cosmo/GitHub/fluentd/vendor/bundle/ruby/3.0.0/gems/fluent-plugin-kafka-0.16.0/lib/fluent/plugin/out_kafka_buffered.rb:239:in `get_producer'
/Users/cosmo/GitHub/fluentd/vendor/bundle/ruby/3.0.0/gems/fluent-plugin-kafka-0.16.0/lib/fluent/plugin/out_kafka_buffered.rb:297:in `write'
/Users/cosmo/GitHub/fluentd/lib/fluent/compat/output.rb:131:in `write'
/Users/cosmo/GitHub/fluentd/lib/fluent/plugin/output.rb:1136:in `try_flush'
/Users/cosmo/GitHub/fluentd/lib/fluent/plugin/output.rb:1448:in `flush_thread_run'
/Users/cosmo/GitHub/fluentd/lib/fluent/plugin/output.rb:462:in `block (2 levels) in start'
/Users/cosmo/GitHub/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2021-03-17 11:30:35 +0900 [info]: #0 initialized kafka producer: kafka
2021-03-17 11:30:35 +0900 [warn]: #0 got unrecoverable error in primary and no secondary error_class=ArgumentError error="wrong number of arguments (given 1, expected 0)"
  2021-03-17 11:30:35 +0900 [warn]: #0 suppressed same stacktrace
2021-03-17 11:30:35 +0900 [warn]: #0 bad chunk is moved to /tmp/fluent/backup/worker0/object_d34/5bdb243f97c20c1b6afd71a5bbb07625.log
```

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>