### PR TITLE
Release v1.16.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Release 0.16.1 - 2021/04/14
+	* out_kafka/out_kafka_buffered: Support Ruby 3.0.0 keyword arguments interop
+	* kafka_plugin_util: Treat empty string in read_ssl_file as nil
+
 Release 0.16.0 - 2021/01/25
 
 	* input: Add `tag_source` and `record_tag_key` parameters for using record field as tag

--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "fluent-plugin-kafka"
   gem.require_paths = ["lib"]
-  gem.version       = '0.16.0'
+  gem.version       = '0.16.1'
   gem.required_ruby_version = ">= 2.1.0"
 
   gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]


### PR DESCRIPTION
This version can be running with Ruby 3.

Our Ruby 3 use case should block Ruby 3 hash interop incompatibility.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>