### PR TITLE
in_kafka: in_kafka_group: Support Ruby 3.0.0 keyword arguments interop

### DIFF
--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -294,7 +294,7 @@ class Fluent::KafkaInput < Fluent::Input
     def consume
       offset = @next_offset
       @fetch_args[:offset] = offset
-      messages = @kafka.fetch_messages(@fetch_args)
+      messages = @kafka.fetch_messages(**@fetch_args)
 
       return if messages.size.zero?
 

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -217,7 +217,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
   end
 
   def setup_consumer
-    consumer = @kafka.consumer(@consumer_opts)
+    consumer = @kafka.consumer(**@consumer_opts)
     @topics.each { |topic|
       if m = /^\/(.+)\/$/.match(topic)
         topic_or_regex = Regexp.new(m[1])


### PR DESCRIPTION
`@producer_opts` and `@consumer_opts` are also needed to hand-written
keyword argumtes interop on Ruby 3.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>