### PR TITLE
Enable excluding record fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ If you want to use zookeeper related parameters, you also need to install zookee
 
 Set path to SSL related files. See [Encryption and Authentication using SSL](https://github.com/zendesk/ruby-kafka#encryption-and-authentication-using-ssl) for more detail.
 
-#### SASL authentication 
+#### SASL authentication
 
 ##### with GSSAPI
 
 - principal
 - keytab
 
-Set principal and path to keytab for SASL/GSSAPI authentication. 
+Set principal and path to keytab for SASL/GSSAPI authentication.
 See [Authentication using SASL](https://github.com/zendesk/ruby-kafka#authentication-using-sasl) for more details.
 
 ##### with Plain/SCRAM
@@ -57,7 +57,7 @@ See [Authentication using SASL](https://github.com/zendesk/ruby-kafka#authentica
 - scram_mechanism
 - sasl_over_ssl
 
-Set username, password, scram_mechanism and sasl_over_ssl for SASL/Plain or Scram authentication. 
+Set username, password, scram_mechanism and sasl_over_ssl for SASL/Plain or Scram authentication.
 See [Authentication using SASL](https://github.com/zendesk/ruby-kafka#authentication-using-sasl) for more details.
 
 ### Input plugin (@type 'kafka')
@@ -315,6 +315,23 @@ And the following fluentd config:
 The Kafka message will have a header of source_ip=12.7.0.0.1.
 
 The configuration format is jsonpath. It is descibed in https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-record_accessor
+
+#### Excluding fields
+Fields can be excluded from output data. Only works for kafka2 and rdkafka2 output plugin.
+
+Fields must be specified using an array of dot notation `$.`, for example:
+
+    <match app.**>
+      @type kafka2
+      [...]
+      exclude_fields $.source.ip,$.HTTP_FOO
+    <match>
+
+This config can be used to remove fields used on another configs.
+
+For example, `$.source.ip` can be extracted with config `headers_from_record` and excluded from message payload.
+
+> Using this config to remove unused fields is discouraged. A [filter plugin](https://docs.fluentd.org/v/0.12/filter) can be used for this purpose.
 
 ### Buffered output plugin
 

--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -241,7 +241,7 @@ DESC
       mutate_headers = !@headers_from_record_accessors.empty?
 
       begin
-        producer = @kafka.topic_producer(topic, @producer_opts)
+        producer = @kafka.topic_producer(topic, **@producer_opts)
         chunk.msgpack_each { |time, record|
           begin
             record = inject_values_to_record(tag, time, record)

--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -260,8 +260,8 @@ DESC
             end
 
             unless @exclude_fields.empty?
-              @exclude_field_accessors.each do |exclude_field_acessor|
-                exclude_field_acessor.delete(record)
+              @exclude_field_accessors.each do |exclude_field_accessor|
+                exclude_field_accessor.delete(record)
               end
             end
 

--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -42,6 +42,8 @@ DESC
                  :desc => 'Set true to remove message key from data'
     config_param :exclude_topic_key, :bool, :default => false,
                  :desc => 'Set true to remove topic name key from data'
+    config_param :exclude_fields, :array, :default => [], value_type: :string,
+                 :desc => 'Fields to remove from data where the value is a jsonpath to a record value'
     config_param :use_event_time, :bool, :default => false, :desc => 'Use fluentd event time for kafka create_time'
     config_param :headers, :hash, default: {}, symbolize_keys: true, value_type: :string,
                  :desc => 'Kafka message headers'
@@ -177,6 +179,10 @@ DESC
       @headers_from_record.each do |key, value|
         @headers_from_record_accessors[key] = record_accessor_create(value)
       end
+
+      @exclude_field_accessors = @exclude_fields.map do |field|
+        record_accessor_create(field)
+      end
     end
 
     def multi_workers_ready?
@@ -251,6 +257,12 @@ DESC
               end
             else
               headers = base_headers
+            end
+
+            unless @exclude_fields.empty?
+              @exclude_field_accessors.each do |exclude_field_acessor|
+                exclude_field_acessor.delete(record)
+              end
             end
 
             record_buf = @formatter_proc.call(tag, time, record)

--- a/test/plugin/test_out_kafka2.rb
+++ b/test/plugin/test_out_kafka2.rb
@@ -1,6 +1,6 @@
 require 'helper'
 require 'fluent/test/helpers'
-require 'fluent/output'
+require 'fluent/test/driver/output'
 
 class Kafka2OutputTest < Test::Unit::TestCase
   include Fluent::Test::Helpers
@@ -56,5 +56,14 @@ class Kafka2OutputTest < Test::Unit::TestCase
   def test_mutli_worker_support
     d = create_driver
     assert_equal true, d.instance.multi_workers_ready?
+  end
+
+  def test_exclude_fields
+    d = create_driver(config + config_element('ROOT', '', {"exclude_fields" => "$.foo"}))
+    d.run do
+      d.feed('test', event_time, {'a' => 'b', 'foo' => 'bar', 'message' => 'test'})
+    end
+
+    assert_equal(1, d.events.size)
   end
 end

--- a/test/plugin/test_out_kafka2.rb
+++ b/test/plugin/test_out_kafka2.rb
@@ -1,6 +1,8 @@
 require 'helper'
 require 'fluent/test/helpers'
+require 'fluent/test/driver/input'
 require 'fluent/test/driver/output'
+require 'securerandom'
 
 class Kafka2OutputTest < Test::Unit::TestCase
   include Fluent::Test::Helpers
@@ -15,8 +17,8 @@ class Kafka2OutputTest < Test::Unit::TestCase
                    ])
   end
 
-  def config
-    base_config + config_element('ROOT', '', {"default_topic" => "kitagawakeiko",
+  def config(default_topic: "kitagawakeiko")
+    base_config + config_element('ROOT', '', {"default_topic" => default_topic,
                                               "brokers" => "localhost:9092"}, [
                                  ])
   end
@@ -58,12 +60,57 @@ class Kafka2OutputTest < Test::Unit::TestCase
     assert_equal true, d.instance.multi_workers_ready?
   end
 
-  def test_exclude_fields
-    d = create_driver(config + config_element('ROOT', '', {"exclude_fields" => "$.foo"}))
-    d.run do
-      d.feed('test', event_time, {'a' => 'b', 'foo' => 'bar', 'message' => 'test'})
+  class WriteTest < self
+    TOPIC_NAME = "kafka-output-#{SecureRandom.uuid}"
+
+    INPUT_CONFIG = %[
+      @type kafka
+      brokers localhost:9092
+      format json
+      @label @kafka
+      topics #{TOPIC_NAME}
+    ]
+
+    def create_target_driver(conf = INPUT_CONFIG)
+      Fluent::Test::Driver::Input.new(Fluent::KafkaInput).configure(conf)
     end
 
-    assert_equal(1, d.events.size)
+    def setup
+      @kafka = Kafka.new(["localhost:9092"], client_id: 'kafka')
+    end
+
+    def teardown
+      @kafka.delete_topic(TOPIC_NAME)
+      @kafka.close
+    end
+
+    def test_write
+      target_driver = create_target_driver
+      expected_message = {"a" => 2}
+      target_driver.run(expect_records: 1, timeout: 5) do
+        sleep 2
+        d = create_driver(config(default_topic: TOPIC_NAME))
+        d.run do
+          d.feed("test", event_time, expected_message)
+        end
+      end
+      actual_messages = target_driver.events.collect { |event| event[2] }
+      assert_equal([expected_message], actual_messages)
+    end
+
+    def test_exclude_fields
+      conf = config(default_topic: TOPIC_NAME) +
+             config_element('ROOT', '', {"exclude_fields" => "$.foo"}, [])
+      target_driver = create_target_driver
+      target_driver.run(expect_records: 1, timeout: 5) do
+        sleep 2
+        d = create_driver(conf)
+        d.run do
+          d.feed('test', event_time, {'a' => 'b', 'foo' => 'bar', 'message' => 'test'})
+        end
+      end
+      actual_messages = target_driver.events.collect { |event| event[2] }
+      assert_equal([{'a' => 'b', 'message' => 'test'}], actual_messages)
+    end
   end
 end


### PR DESCRIPTION
I would like to exclude fields from message record.

This is desirable when using another configs such as `headers_from_record`, wich duplicates data to message headers. With this config will be possible to move data to headers and remove from the message payload.