### PR TITLE
Suppress warnings while running tests

### DIFF
--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -71,6 +71,7 @@ class Fluent::KafkaInput < Fluent::Input
     require 'kafka'
 
     @time_parser = nil
+    @zookeeper = nil
   end
 
   def configure(conf)

--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -88,6 +88,7 @@ DESC
     require 'kafka'
 
     @kafka = nil
+    @field_separator = nil
   end
 
   def refresh_client

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -107,6 +107,7 @@ DESC
     @kafka = nil
     @producers = {}
     @producers_mutex = Mutex.new
+    @field_separator = nil
   end
 
   def multi_workers_ready?


### PR DESCRIPTION
Suppress the following warnings:
```
/home/runner/work/fluent-plugin-kafka/fluent-plugin-kafka/lib/fluent/plugin/out_kafka_buffered.rb:181: warning: instance variable @field_separator not initialized
/home/runner/work/fluent-plugin-kafka/fluent-plugin-kafka/lib/fluent/plugin/in_kafka.rb:244: warning: instance variable @zookeeper not initialized
/home/runner/work/fluent-plugin-kafka/fluent-plugin-kafka/lib/fluent/plugin/out_kafka.rb:153: warning: instance variable @field_separator not initialized
```

Signed-off-by: Takuro Ashie <ashie@clear-code.com>