### PR TITLE
Adapt the logger to rdkafka 0.9.0 or later

### DIFF
--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -112,23 +112,29 @@ DESC
     def configure(conf)
       super
       log.instance_eval {
-        def add(level, &block)
-          return unless block
+        def add(level, message = nil)
+          if message.nil?
+            if block_given?
+              message = yield
+            else
+              return
+            end
+          end
 
           # Follow rdkakfa's log level. See also rdkafka-ruby's bindings.rb: https://github.com/appsignal/rdkafka-ruby/blob/e5c7261e3f2637554a5c12b924be297d7dca1328/lib/rdkafka/bindings.rb#L117
           case level
           when Logger::FATAL
-            self.fatal(block.call)
+            self.fatal(message)
           when Logger::ERROR
-            self.error(block.call)
+            self.error(message)
           when Logger::WARN
-            self.warn(block.call)
+            self.warn(message)
           when Logger::INFO
-            self.info(block.call)
+            self.info(message)
           when Logger::DEBUG
-            self.debug(block.call)
+            self.debug(message)
           else
-            self.trace(block.call)
+            self.trace(message)
           end
         end
       }


### PR DESCRIPTION
The usage of `Rdkafka::Config.logger.add` is changed since 0.9.0:

https://github.com/appsignal/rdkafka-ruby/commit/3f9e5045e09420b5213859b02fae894bb001caf2#diff-98e932d49ef97cb9149e0d0e280d10f841f644f6f1b3b67313552fff22b16a33

It should be same behaviour with `Logger#add`

Fix #414

Signed-off-by: Takuro Ashie <ashie@clear-code.com>