### PR TITLE
out_kafka_buffered: Don't output skipped large events as warning log

### DIFF
--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -332,7 +332,8 @@ DESC
           record_buf = @formatter_proc.call(tag, time, record)
           record_buf_bytes = record_buf.bytesize
           if @max_send_limit_bytes && record_buf_bytes > @max_send_limit_bytes
-            log.warn "record size exceeds max_send_limit_bytes. Skip event:", :time => time, :record => record
+            log.warn "record size exceeds max_send_limit_bytes. Skip event:", :time => time, :record_size => record_buf_bytes
+            log.debug "Skipped event:", :record => record
             next
           end
         rescue StandardError => e


### PR DESCRIPTION
Follow up for #437

Signed-off-by: Takuro Ashie <ashie@clear-code.com>