### PR TITLE
in_kafka_group: add refresh_topic_interval parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Consume events by kafka consumer group features..
       offset_commit_interval  (integer) :default => nil (Use default of ruby-kafka)
       offset_commit_threshold (integer) :default => nil (Use default of ruby-kafka)
       fetcher_max_queue_size  (integer) :default => nil (Use default of ruby-kafka)
+      refresh_topic_interval  (integer) :default => nil (Use default of ruby-kafka)
       start_from_beginning    (bool)    :default => true
     </source>
 

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -67,6 +67,8 @@ class Fluent::KafkaGroupInput < Fluent::Input
                :desc => "The number of messages that can be processed before their offsets are committed"
   config_param :fetcher_max_queue_size, :integer, :default => nil,
                :desc => "The number of fetched messages per partition that are queued in fetcher queue"
+  config_param :refresh_topic_interval, :integer, :default => nil,
+               :desc => "The interval of refreshing the topic list in seconds. Zero or unset disables this"
   config_param :start_from_beginning, :bool, :default => true,
                :desc => "Whether to start from the beginning of the topic or just subscribe to new messages being produced"
 
@@ -128,6 +130,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
     @consumer_opts[:offset_commit_interval] = @offset_commit_interval if @offset_commit_interval
     @consumer_opts[:offset_commit_threshold] = @offset_commit_threshold if @offset_commit_threshold
     @consumer_opts[:fetcher_max_queue_size] = @fetcher_max_queue_size if @fetcher_max_queue_size
+    @consumer_opts[:refresh_topic_interval] = @refresh_topic_interval if @refresh_topic_interval
 
     @fetch_opts = {}
     @fetch_opts[:max_wait_time] = @max_wait_time if @max_wait_time

--- a/test/plugin/test_in_kafka_group.rb
+++ b/test/plugin/test_in_kafka_group.rb
@@ -14,6 +14,7 @@ class KafkaGroupInputTest < Test::Unit::TestCase
     brokers localhost:9092
     consumer_group fluentd
     format text
+    refresh_topic_interval 0
     @label @kafka
     topics #{TOPIC_NAME}
   ]
@@ -52,6 +53,7 @@ class KafkaGroupInputTest < Test::Unit::TestCase
         brokers localhost:9092
         format text
         @label @kafka
+        refresh_topic_interval 0
         topics #{TOPIC_NAME}
       ]
       d = create_driver


### PR DESCRIPTION
Add parameter `refresh_topic_interval` which sets how often ruby-kafka
will refresh the list of topics. This is especially important to us
because new topics are very likely to be created and we want to consume
messages from them automatically.

Fixes https://github.com/fluent/fluent-plugin-kafka/issues/383.

Relevant code from ruby-kafka:
https://github.com/zendesk/ruby-kafka/blob/v1.4.0/lib/kafka/client.rb#L364