### PR TITLE
Feat/add record key config rdkafka2

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ You need to install rdkafka gem.
       # same with kafka2
       headers               (hash) :default => {}
       headers_from_record   (hash) :default => {}
+      record_key            (string) :default => nil
 
       <format>
         @type (json|ltsv|msgpack|attr:<record name>|<formatter name>) :default => json

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ If `ruby-kafka` doesn't fit your kafka environment, check `rdkafka2` plugin inst
       message_key_key       (string) :default => 'message_key'
       default_topic         (string) :default => nil
       default_partition_key (string) :default => nil
+      record_key            (string) :default => nil
       default_message_key   (string) :default => nil
       exclude_topic_key     (bool)   :default => false
       exclude_partition_key (bool)   :default => false

--- a/test/plugin/test_out_kafka2.rb
+++ b/test/plugin/test_out_kafka2.rb
@@ -105,6 +105,21 @@ class Kafka2OutputTest < Test::Unit::TestCase
       assert_equal([expected_message], actual_messages)
     end
 
+    def test_record_key
+      conf = config(default_topic: TOPIC_NAME) +
+        config_element('ROOT', '', {"record_key" => "$.data"}, [])
+      target_driver = create_target_driver
+      target_driver.run(expect_records: 1, timeout: 5) do
+        sleep 2
+        d = create_driver(conf)
+        d.run do
+          d.feed('test', event_time, {'data' => {'a' => 'b', 'foo' => 'bar', 'message' => 'test'}, 'message_key' => '123456'})
+        end
+      end
+      actual_messages = target_driver.events.collect { |event| event[2] }
+      assert_equal([{'a' => 'b', 'foo' => 'bar', 'message' => 'test'}], actual_messages)
+    end
+
     def test_exclude_fields
       conf = config(default_topic: TOPIC_NAME) +
              config_element('ROOT', '', {"exclude_fields" => "$.foo"}, [])

--- a/test/plugin/test_out_rdkafka2.rb
+++ b/test/plugin/test_out_rdkafka2.rb
@@ -163,5 +163,20 @@ class Rdkafka2OutputTest < Test::Unit::TestCase
       actual_messages = target_driver.events.collect { |event| event[2] }
       assert_equal(expected_messages, actual_messages)
     end
+
+    def test_record_key
+      conf = config(default_topic: TOPIC_NAME) +
+             config_element('ROOT', '', {"record_key" => "$.data"}, [])
+      target_driver = create_target_driver
+      target_driver.run(expect_records: 1, timeout: 5) do
+        sleep 2
+        d = create_driver(conf)
+        d.run do
+          d.feed('test', event_time, {'data' => {'a' => 'b', 'foo' => 'bar', 'message' => 'test'}, 'message_key' => '123456'})
+        end
+      end
+      actual_messages = target_driver.events.collect { |event| event[2] }
+      assert_equal([{'a' => 'b', 'foo' => 'bar', 'message' => 'test'}], actual_messages)
+    end
   end
 end


### PR DESCRIPTION
Addresses https://github.com/fluent/fluent-plugin-kafka/issues/450.

Same as https://github.com/fluent/fluent-plugin-kafka/pull/451 but for `rdkafkaf2` instead. I've branched this off the #451 branch, so it's preferable to merge #451 first. Also happy to combine these 2 PRs into 1
