### PR TITLE
perf(out_kafka2): Reusing Kafka connections between flushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ If `ruby-kafka` doesn't fit your kafka environment, check `rdkafka2` plugin inst
       use_default_for_unknown_topic (bool) :default => false
       discard_kafka_delivery_failed (bool) :default => false (No discard)
       partitioner_hash_function (enum) (crc32|murmur2) :default => 'crc32'
+      share_producer        (bool)   :default => false
 
       <format>
         @type (json|ltsv|msgpack|attr:<record name>|<formatter name>) :default => json


### PR DESCRIPTION
Hey :wave: 

This PR changes the output `kafka2` plugin to reuse Kafka connections between flushes. Majority of the logic is lifted-and-shifted from the output `rdkafka2` plugin. I'm not able to run the unit test locally to verify whether this is working unfortunately (More than happy to create a follow up PR so we can run our test locally though!). It would be awesome if we can trigger a CI run to verify things are not broken :bowing_man:.

Thanks a bunch!

Some data points on why this is important:

- We were using https://github.com/fluent-plugins-nursery/fluent-plugin-formatter-protobuf as our formatter, in combination with the `kafka2` output plugin, we're able to comfortably handle ~4,500 - 5,000 messages per second per container (2 vCPU, 2GB memory each)
- We have load tested fluentd with https://github.com/fluent-plugins-nursery/fluent-plugin-formatter-protobuf as the formatter using the output `kafka2` plugin at 200,000 messages per second to Confluent Cloud dedicated cluster at 2 CKU with `idempotent` set to `true`. All 3 Kafka brokers crashed due to OOM after ~30mins. This is due to TCP connections churn and the broker keeps some state in memory due to idempotency. Confluent Cloud's `cluster_load_percent` metric reached 100% due to the memory issue
- We swapped over to using `rdkafka2` plugin, and due to the fact that it's reusing connections, Confluent Cloud's `cluster_load_percent` was never above 3% at 200,000 messages per second (~16MBps throughput). However, we found the performance per container dropped by about 40 - 50%, and we were only able to achieve ~2,500 - 3,000 messages per second per container.