### PR TITLE
fix(out_rdkafka2): fixed a bug where it is not respecting the Buffer sections' `chunk_limit_records` and `chunk_limit_size` options

### DIFF
--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -207,7 +207,7 @@ DESC
     end
 
     def create_producer
-      @kafka.producer(**@producer_opts)
+      @kafka.custom_producer(**@producer_opts)
     end
 
     def start


### PR DESCRIPTION
Fixes https://github.com/fluent/fluent-plugin-kafka/issues/462

Additionally, I just realised there's also a slight behavior change made in https://github.com/fluent/fluent-plugin-kafka/pull/454.

Prior to that commit, we were fetching Kafka topic related metadata only for the given topics, but that commit changes it such that the plugin fetches metadata for all topics. I don't think this will cause too much of an impact in production, but worth calling it out anyway.