### PR TITLE
fix(out_rdkafka2): fix compatibility with rdkafka 0.12.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,10 @@ jobs:
         ruby: [ '3.1', '3.0', '2.7', '2.6' ]
         os:
           - ubuntu-latest
-    name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
+        rdkafka_versions:
+          - { min: '>= 0.6.0', max: '< 0.12.0' }
+          - { min: '>= 0.12.0', max: '>= 0.12.0' }
+    name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }} with rdkafka gem version (min ${{ matrix.rdkafka_versions.min }} max ${{ matrix.rdkafka_versions.max }})
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
@@ -33,6 +36,8 @@ jobs:
     - name: unit testing
       env:
         CI: true
+        RDKAFKA_VERSION_MIN_RANGE: ${{ matrix.rdkafka_versions.min }}
+        RDKAFKA_VERSION_MAX_RANGE: ${{ matrix.rdkafka_versions.max }}
       run: |
         sudo ./ci/prepare-kafka-server.sh
         gem install bundler rake

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in fluent-plugin-kafka.gemspec
 gemspec
 
-gem 'rdkafka', '>= 0.6.0' if ENV["USE_RDKAFKA"]
+gem 'rdkafka', ENV['RDKAFKA_VERSION_MIN_RANGE'], ENV['RDKAFKA_VERSION_MAX_RANGE'] if ENV['USE_RDKAFKA']

--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -30,7 +30,7 @@ class Rdkafka::Producer
   def close(timeout = nil)
     rdkafka_version = Rdkafka::VERSION || '0.0.0'
     # Rdkafka version >= 0.12.0 changed its internals
-    if rdkafka_version.split('.')[1].to_i >= 12
+    if Gem::Version::create(rdkafka_version) >= Gem::Version.create('0.12.0')
       ObjectSpace.undefine_finalizer(self)
 
       return @client.close(timeout)

--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -5,9 +5,37 @@ require 'fluent/plugin/kafka_plugin_util'
 
 require 'rdkafka'
 
+# This is required for `rdkafka` version >= 0.12.0
+# Overriding the close method in order to provide a time limit for when it should be forcibly closed
+class Rdkafka::Producer::Client
+  # return false if producer is forcefully closed, otherwise return true
+  def close(timeout=nil)
+    return unless @native
+
+    # Indicate to polling thread that we're closing
+    @polling_thread[:closing] = true
+    # Wait for the polling thread to finish up
+    thread = @polling_thread.join(timeout)
+
+    Rdkafka::Bindings.rd_kafka_destroy(@native)
+
+    @native = nil
+
+    return !thread.nil?
+  end
+end
+
 class Rdkafka::Producer
   # return false if producer is forcefully closed, otherwise return true
   def close(timeout = nil)
+    rdkafka_version = Rdkafka::VERSION || '0.0.0'
+    # Rdkafka version >= 0.12.0 changed its internals
+    if rdkafka_version.split('.')[1].to_i >= 12
+      ObjectSpace.undefine_finalizer(self)
+
+      return @client.close(timeout)
+    end
+
     @closing = true
     # Wait for the polling thread to finish up
     # If the broker isn't alive, the thread doesn't exit


### PR DESCRIPTION
Fixes https://github.com/fluent/fluent-plugin-kafka/issues/463

I think this is the simplest implementation that I could find to support rdkafka 0.12.0, but unfortunately because of how we're monkey patching the methods, it means we'd have to drop support for < 0.12.0 thus making this a breaking change.

Not sure if this is the right place to propose whether we should consider splitting out rdkafka into its own plugin (say `fluent-plugin-rdkafka`) so we're able to put the rdkafka gem as a dependency in the gemspec and give it a proper version range.

The "test" for this change is that I have created a separate PR that only bumps rdkafka gem to 0.12.0 and nothing else. https://github.com/fluent/fluent-plugin-kafka/pull/469, then check its unit test logs https://github.com/fluent/fluent-plugin-kafka/runs/7878417388?check_suite_focus=true#step:5:1030

Comparing to the test logs for this PR, https://github.com/fluent/fluent-plugin-kafka/runs/7878310221?check_suite_focus=true, we don't see any more `NoMethodError:undefined method 'join' for nil:NilClass` errors.

