### PR TITLE
GitHub issue: Set waiting-for-triage by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Create a report with a procedure for reproducing the bug
+labels: "waiting-for-triage"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,6 @@
 name: Feature request
 description: Suggest an idea for this project
+labels: "waiting-for-triage"
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/stale-actions.yml
+++ b/.github/workflows/stale-actions.yml
@@ -18,5 +18,7 @@ jobs:
         close-pr-message: "This PR was automatically closed because of stale in 30 days"
         stale-pr-label: "stale"
         stale-issue-label: "stale"
-        exempt-issue-labels: "bug,enhancement,help wanted"
-        exempt-pr-labels: "bug,enhancement,help wanted"
+        exempt-issue-labels: "bug,enhancement,help wanted,waiting-for-triage"
+        exempt-pr-labels: "bug,enhancement,help wanted,waiting-for-triage"
+        exempt-all-assignees: true
+        exempt-all-milestones: true


### PR DESCRIPTION
We might not check issues so often recent days, so it is inappropriate to close stale issues that aren't checked by any maintainers. This commit will add waiting-for-triage label to all new issues and won't close them by default. In addition, issues that are assigned or set milestone are also exempted.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>