### PR TITLE
feat(out_rdkafka2): adds `use_default_for_unknown_topic` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ You need to install rdkafka gem.
       partition_key_key     (string) :default => 'partition_key'
       message_key_key       (string) :default => 'message_key'
       default_topic         (string) :default => nil
+      use_default_for_unknown_topic (bool) :default => false
       default_partition_key (string) :default => nil
       default_message_key   (string) :default => nil
       exclude_topic_key     (bool) :default => false


### PR DESCRIPTION
Addresses https://github.com/fluent/fluent-plugin-kafka/issues/489

This lifts the same parameter from the `out_kafka2` plugin and behaves similarly - it first attempts to write to a given topic, and if it fails because the topic does not exist, it will attempt to write to the `default_topic`