### PR TITLE
Enhancement : Add "discard_kafka_delivery_failed_regex" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ You need to install rdkafka gem.
       exclude_topic_key     (bool) :default => false
       exclude_partition_key (bool) :default => false
       discard_kafka_delivery_failed (bool) :default => false (No discard)
+      discard_kafka_delivery_failed_regex (regexp) :default => nil (No discard)
       use_event_time        (bool) :default => false
 
       # same with kafka2
@@ -558,6 +559,9 @@ You need to install rdkafka gem.
       # to send. Default is no limit.
       max_enqueue_bytes_per_second (integer) :default => nil
     </match>
+
+`rdkafka2` supports `discard_kafka_delivery_failed_regex` parameter:
+- `discard_kafka_delivery_failed_regex` - default: nil - discard the record where the Kafka::DeliveryFailed occurred and the emitted message matches the given regex pattern, such as `/unknown_topic/`. 
 
 If you use v0.12, use `rdkafka` instead.
 

--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -65,6 +65,8 @@ DESC
     config_param :topic_key, :string, :default => 'topic', :desc => "Field for kafka topic"
     config_param :default_topic, :string, :default => nil,
                  :desc => "Default output topic when record doesn't have topic field"
+    config_param :use_default_for_unknown_topic, :bool, :default => false, :desc => "If true, default_topic is used when topic not found"
+    config_param :use_default_for_unknown_partition_error, :bool, :default => false, :desc => "If true, default_topic is used when received unknown_partition error"
     config_param :message_key_key, :string, :default => 'message_key', :desc => "Field for kafka message key"
     config_param :default_message_key, :string, :default => nil
     config_param :partition_key, :string, :default => 'partition', :desc => "Field for kafka partition"
@@ -234,6 +236,9 @@ DESC
       @rdkafka = Rdkafka::Config.new(config)
 
       if @default_topic.nil?
+        if @use_default_for_unknown_topic || @use_default_for_unknown_partition_error
+          raise Fluent::ConfigError, "default_topic must be set when use_default_for_unknown_topic or use_default_for_unknown_partition_error is true"
+        end
         if @chunk_keys.include?(@topic_key) && !@chunk_key_tag
           log.warn "Use '#{@topic_key}' field of event record for topic but no fallback. Recommend to set default_topic or set 'tag' in buffer chunk keys like <buffer #{@topic_key},tag>"
         end
@@ -471,17 +476,25 @@ DESC
 
     def enqueue_with_retry(producer, topic, record_buf, message_key, partition, headers, time)
       attempt = 0
+      actual_topic = topic
+
       loop do
         begin
           @enqueue_rate.raise_if_limit_exceeded(record_buf.bytesize) if @enqueue_rate
-          return producer.produce(topic: topic, payload: record_buf, key: message_key, partition: partition, headers: headers, timestamp: @use_event_time ? Time.at(time) : nil)
+          return producer.produce(topic: actual_topic, payload: record_buf, key: message_key, partition: partition, headers: headers, timestamp: @use_event_time ? Time.at(time) : nil)
         rescue EnqueueRate::LimitExceeded => e
           @enqueue_rate.revert if @enqueue_rate
           duration = e.next_retry_clock - Fluent::Clock.now
           sleep(duration) if duration > 0.0
         rescue Exception => e
           @enqueue_rate.revert if @enqueue_rate
-          if e.respond_to?(:code) && e.code == :queue_full
+
+          if !e.respond_to?(:code)
+            raise e
+          end
+
+          case e.code
+          when :queue_full
             if attempt <= @max_enqueue_retries
               log.warn "Failed to enqueue message; attempting retry #{attempt} of #{@max_enqueue_retries} after #{@enqueue_retry_backoff}s"
               sleep @enqueue_retry_backoff
@@ -489,6 +502,25 @@ DESC
             else
               raise "Failed to enqueue message although tried retry #{@max_enqueue_retries} times"
             end
+          # https://github.com/confluentinc/librdkafka/blob/c282ba2423b2694052393c8edb0399a5ef471b3f/src/rdkafka.h#LL309C9-L309C41
+          # RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC
+          when :unknown_topic
+            if @use_default_for_unknown_topic && actual_topic != @default_topic
+              log.debug "'#{actual_topic}' topic not found. Retry with '#{@default_topic}' topic"
+              actual_topic = @default_topic
+              retry
+            end
+            raise e
+          # https://github.com/confluentinc/librdkafka/blob/c282ba2423b2694052393c8edb0399a5ef471b3f/src/rdkafka.h#L305
+          # RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION
+          when :unknown_partition
+            if @use_default_for_unknown_partition_error && actual_topic != @default_topic
+              log.debug "failed writing to topic '#{actual_topic}' with error '#{e.to_s}'. Writing message to topic '#{@default_topic}'"
+              actual_topic = @default_topic
+              retry
+            end
+
+            raise e
           else
             raise e
           end

--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -65,8 +65,6 @@ DESC
     config_param :topic_key, :string, :default => 'topic', :desc => "Field for kafka topic"
     config_param :default_topic, :string, :default => nil,
                  :desc => "Default output topic when record doesn't have topic field"
-    config_param :use_default_for_unknown_topic, :bool, :default => false, :desc => "If true, default_topic is used when topic not found"
-    config_param :use_default_for_unknown_partition_error, :bool, :default => false, :desc => "If true, default_topic is used when received unknown_partition error"
     config_param :message_key_key, :string, :default => 'message_key', :desc => "Field for kafka message key"
     config_param :default_message_key, :string, :default => nil
     config_param :partition_key, :string, :default => 'partition', :desc => "Field for kafka partition"
@@ -112,6 +110,7 @@ DESC
     config_param :use_event_time, :bool, :default => false, :desc => 'Use fluentd event time for rdkafka timestamp'
     config_param :max_send_limit_bytes, :size, :default => nil
     config_param :discard_kafka_delivery_failed, :bool, :default => false
+    config_param :discard_kafka_delivery_failed_regex, :regexp, :default => nil
     config_param :rdkafka_buffering_max_ms, :integer, :default => nil, :desc => 'Used for queue.buffering.max.ms'
     config_param :rdkafka_buffering_max_messages, :integer, :default => nil, :desc => 'Used for queue.buffering.max.messages'
     config_param :rdkafka_message_max_bytes, :integer, :default => nil, :desc => 'Used for message.max.bytes'
@@ -235,9 +234,6 @@ DESC
       @rdkafka = Rdkafka::Config.new(config)
 
       if @default_topic.nil?
-        if @use_default_for_unknown_topic || @use_default_for_unknown_partition_error
-          raise Fluent::ConfigError, "default_topic must be set when use_default_for_unknown_topic or use_default_for_unknown_partition_error is true"
-        end
         if @chunk_keys.include?(@topic_key) && !@chunk_key_tag
           log.warn "Use '#{@topic_key}' field of event record for topic but no fallback. Recommend to set default_topic or set 'tag' in buffer chunk keys like <buffer #{@topic_key},tag>"
         end
@@ -461,9 +457,13 @@ DESC
       if @discard_kafka_delivery_failed
         log.warn "Delivery failed. Discard events:", :error => e.to_s, :error_class => e.class.to_s, :tag => tag
       else
-        log.warn "Send exception occurred: #{e} at #{e.backtrace.first}"
-        # Raise exception to retry sendind messages
-        raise e
+	if @discard_kafka_delivery_failed_regex != nil && @discard_kafka_delivery_failed_regex.match?(e.to_s)
+          log.warn "Delivery failed and matched regexp pattern #{@discard_kafka_delivery_failed_regex}. Discard events:", :error => e.to_s, :error_class => e.class.to_s, :tag => tag
+	else
+	  log.warn "Send exception occurred: #{e} at #{e.backtrace.first}"
+          # Raise exception to retry sendind messages
+          raise e
+	end
       end
     ensure
       @writing_threads_mutex.synchronize { @writing_threads.delete(Thread.current) }
@@ -471,25 +471,17 @@ DESC
 
     def enqueue_with_retry(producer, topic, record_buf, message_key, partition, headers, time)
       attempt = 0
-      actual_topic = topic
-
       loop do
         begin
           @enqueue_rate.raise_if_limit_exceeded(record_buf.bytesize) if @enqueue_rate
-          return producer.produce(topic: actual_topic, payload: record_buf, key: message_key, partition: partition, headers: headers, timestamp: @use_event_time ? Time.at(time) : nil)
+          return producer.produce(topic: topic, payload: record_buf, key: message_key, partition: partition, headers: headers, timestamp: @use_event_time ? Time.at(time) : nil)
         rescue EnqueueRate::LimitExceeded => e
           @enqueue_rate.revert if @enqueue_rate
           duration = e.next_retry_clock - Fluent::Clock.now
           sleep(duration) if duration > 0.0
         rescue Exception => e
           @enqueue_rate.revert if @enqueue_rate
-
-          if !e.respond_to?(:code)
-            raise e
-          end
-
-          case e.code
-          when :queue_full
+          if e.respond_to?(:code) && e.code == :queue_full
             if attempt <= @max_enqueue_retries
               log.warn "Failed to enqueue message; attempting retry #{attempt} of #{@max_enqueue_retries} after #{@enqueue_retry_backoff}s"
               sleep @enqueue_retry_backoff
@@ -497,25 +489,6 @@ DESC
             else
               raise "Failed to enqueue message although tried retry #{@max_enqueue_retries} times"
             end
-          # https://github.com/confluentinc/librdkafka/blob/c282ba2423b2694052393c8edb0399a5ef471b3f/src/rdkafka.h#LL309C9-L309C41
-          # RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC
-          when :unknown_topic
-            if @use_default_for_unknown_topic && actual_topic != @default_topic
-              log.debug "'#{actual_topic}' topic not found. Retry with '#{@default_topic}' topic"
-              actual_topic = @default_topic
-              retry
-            end
-            raise e
-          # https://github.com/confluentinc/librdkafka/blob/c282ba2423b2694052393c8edb0399a5ef471b3f/src/rdkafka.h#L305
-          # RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION
-          when :unknown_partition
-            if @use_default_for_unknown_partition_error && actual_topic != @default_topic
-              log.debug "failed writing to topic '#{actual_topic}' with error '#{e.to_s}'. Writing message to topic '#{@default_topic}'"
-              actual_topic = @default_topic
-              retry
-            end
-
-            raise e
           else
             raise e
           end


### PR DESCRIPTION
When with Forwarder and Aggregator architecture, forwarders sometimes send invalid data which cause delivery failure at aggregators. `out_rdkafka2` plugin has`discard_kafka_delivery_failed` but it potentially discards not only unnecessary events but also required events, e.g. users expect Fluentd to keep events in buffer files during the outage of Kafka cluster (due to maintenance for instance) but all events are discarded when with `discard_kafka_delivery_failed`.
This enhancement request proposes having `discard_kafka_delivery_failed_regex` option on `out_rdkafka2` plugin to nullify invalid data by checking the error message with given regexp pattern.

Here is a sample use case:
In the following configuration, dummy events are generated with tag `test-topic0001` and Fluentd try to ship message to `test-topic0001`. If `test-topic0001` does not exist in Kafka cluster, `out_rdkafka2` emits a `Local: Unknown topic (unknown_topic)` warning message. With `discard_kafka_delivery_failed_regex /Unknown topic/`, `out_rdkafka2` discards events which emits a `Local: Unknown topic (unknown_topic)` warning message.

```
<source>
  @type dummy
  sample {"Hello":"World"}
  tag test-topic0001
</source>

<match dummy>
    @type rdkafka2
    @id "rdkafka2"
    bokers kafka01.demo.local:9093, kafka02.demo.local:9093
    discard_kafka_delivery_failed_regex /Unknown topic/
    required_acks 1
    ack_timeout 20
    share_producer true
    ## Buffer settings
    <buffer tag>
      @type file
      path ./buffer/
      flush_interval 5s
    </buffer>
    <format>
      @type json
    </format>
</match>
```

