### PR TITLE
out_rdkafka2: enable idempotency for kafka producers

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ If `ruby-kafka` doesn't fit your kafka environment, check `rdkafka2` plugin inst
       discard_kafka_delivery_failed (bool) :default => false (No discard)
       partitioner_hash_function (enum) (crc32|murmur2) :default => 'crc32'
       share_producer        (bool)   :default => false
+      idempotent            (bool)   :default => false
 
       # If you intend to rely on AWS IAM auth to MSK with long lived credentials
       # https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html

--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -71,6 +71,7 @@ DESC
     config_param :default_message_key, :string, :default => nil
     config_param :partition_key, :string, :default => 'partition', :desc => "Field for kafka partition"
     config_param :default_partition, :integer, :default => nil
+    config_param :idempotent, :bool, :default => false, :desc => 'Enable idempotent producer'
     config_param :output_data_type, :string, :default => 'json', :obsoleted => "Use <format> section instead"
     config_param :output_include_tag, :bool, :default => false, :obsoleted => "Use <inject> section instead"
     config_param :output_include_time, :bool, :default => false, :obsoleted => "Use <inject> section instead"
@@ -313,6 +314,7 @@ DESC
       config[:"batch.num.messages"] = @rdkafka_message_max_num if @rdkafka_message_max_num
       config[:"sasl.username"] = @username if @username
       config[:"sasl.password"] = @password if @password
+      config[:"enable.idempotence"] = @idempotent if @idempotent
 
       @rdkafka_options.each { |k, v|
         config[k.to_sym] = v


### PR DESCRIPTION
**Which issue(s) this PR fixes:**
None.

**What this PR does / why we need it:**
In order to enable Idempotency for kafka producers, rdkafka allowes us to enable this. ([here](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md/#L137))

**Docs Changes:**
README.md : Added to usage template for better visibility. 

**Release Note:**
Same as the title.