### PR TITLE
out_kafka2: Broker pool to take care of fetching metadata

### DIFF
--- a/lib/fluent/plugin/kafka_producer_ext.rb
+++ b/lib/fluent/plugin/kafka_producer_ext.rb
@@ -93,6 +93,10 @@ module Kafka
       @max_buffer_bytesize = max_buffer_bytesize
       @compressor = compressor
       @partitioner = partitioner
+
+      # The set of topics that are produced to.
+      @target_topics = Set.new
+
       # A buffer organized by topic/partition.
       @buffer = MessageBuffer.new
 
@@ -116,7 +120,8 @@ module Kafka
       if @transaction_manager.transactional? && !@transaction_manager.in_transaction?
         raise 'You must trigger begin_transaction before producing messages'
       end
-
+      
+      @target_topics.add(topic)
       @pending_message_queue.write(message)
 
       nil
@@ -187,7 +192,7 @@ module Kafka
     def deliver_messages_with_retries
       attempt = 0
 
-      #@cluster.add_target_topics(@target_topics)
+      @cluster.add_target_topics(@target_topics)
 
       operation = ProduceOperation.new(
         cluster: @cluster,


### PR DESCRIPTION
Which issue(s) this PR fixes:
https://github.com/fluent/fluent-plugin-kafka/issues/502

What this PR does / why we need it:
On enabling the get_kafka_client_log true, this can be figured out the leader of partitions is being queried multiple times: [here](https://github.com/zendesk/ruby-kafka/blob/62a0cf9c44b0c05a4f98c4ec073ae5f04f4194e0/lib/kafka/produce_operation.rb#L77C15-L77C15)
this metadata if refreshed by broker pool ([here](https://github.com/zendesk/ruby-kafka/commit/ffc1a341e923041c12fd230fdf1ff2f8b8c2e8df)). Adding this in producer would resolve the issue. 
additionally, this is a part of an optimisation done on ruby-kafka. 

Test cases passing post the changes.

Docs Changes:
NA

