### PR TITLE
Update target ruby versions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.1', '3.0', '2.7' ]
+        ruby: [ '3.2', '3.1' ]
         os:
           - ubuntu-latest
         rdkafka_versions:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.1' ]
+        ruby: [ '3.3', '3.2', '3.1' ]
         os:
           - ubuntu-latest
         rdkafka_versions:


### PR DESCRIPTION

 Drop deprecated ruby version

    * 3.0: EOL 2024-04-23
    * 2.7: EOL 2023-03-31

ref. https://www.ruby-lang.org/en/downloads/branches/

Then add Ruby 3.3 for test matrix
