### PR TITLE
Apply PR#468 patch only for 0.12.x.

### DIFF
--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -30,7 +30,10 @@ class Rdkafka::Producer
   def close(timeout = nil)
     rdkafka_version = Rdkafka::VERSION || '0.0.0'
     # Rdkafka version >= 0.12.0 changed its internals
-    if Gem::Version::create(rdkafka_version) >= Gem::Version.create('0.12.0')
+    # but reverted in >= 0.13.0
+    gem_version = Gem::Version::create(rdkafka_version)
+    if gem_version >= Gem::Version.create('0.12.0') and
+      gem_version <= Gem::Version.create('0.12.1')
       ObjectSpace.undefine_finalizer(self)
 
       return @client.close(timeout)


### PR DESCRIPTION
With https://github.com/fluent/fluent-plugin-kafka/pull/468,
 rdkafka 0.12.0 specific patch was introduced, but rdkafka's internal change
was reverted later in 0.13.x.

So this monkey patch should be effective only between 0.12.0 and 0.12.1 (only 2 versions were shipped in 0.12.x).
For 0.13.x or later, it seems harmful.