### PR TITLE
Revert "Apply PR#468 patch only for 0.12.x."

### DIFF
--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -30,10 +30,7 @@ class Rdkafka::Producer
   def close(timeout = nil)
     rdkafka_version = Rdkafka::VERSION || '0.0.0'
     # Rdkafka version >= 0.12.0 changed its internals
-    # but reverted in >= 0.13.0
-    gem_version = Gem::Version::create(rdkafka_version)
-    if gem_version >= Gem::Version.create('0.12.0') and
-      gem_version <= Gem::Version.create('0.12.1')
+    if Gem::Version::create(rdkafka_version) >= Gem::Version.create('0.12.0')
       ObjectSpace.undefine_finalizer(self)
 
       return @client.close(timeout)


### PR DESCRIPTION
Reverts fluent/fluent-plugin-kafka#513

#505 is better approach to fix this problem, so revert this PR.
