### PR TITLE
ci: use bundler installed by ruby/setup-ruby action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,18 +20,14 @@ jobs:
           - { min: '>= 0.12.0', max: '< 0.14.0' }
           - { min: '>= 0.14.0', max: '< 0.16.0' }
           - { min: '>= 0.16.0', max: '>= 0.16.0' }
-        bundler_version:
-          - '2.5.16'
         # rdkafka 0.15.2 is the last version which supports Ruby 2.7
         include:
           - ruby: '2.7'
             os: ubuntu-latest
             rdkafka_versions: { min: '>= 0.6.0', max: '< 0.12.0' }
-            bundler_version: '2.4.22'
           - ruby: '2.7'
             os: ubuntu-latest
             rdkafka_versions: { min: '>= 0.12.0', max: '= 0.15.2' }
-            bundler_version: '2.4.22'
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }} with rdkafka gem version (min ${{ matrix.rdkafka_versions.min }} max ${{ matrix.rdkafka_versions.max }})
     steps:
     - uses: actions/checkout@v4
@@ -54,7 +50,6 @@ jobs:
         RDKAFKA_VERSION_MAX_RANGE: ${{ matrix.rdkafka_versions.max }}
       run: |
         sudo ./ci/prepare-kafka-server.sh
-        gem install bundler -v ${{ matrix.bundler_version }}
         gem install rake
-        bundle _${{ matrix.bundler_version }}_ install --jobs 4 --retry 3
-        bundle _${{ matrix.bundler_version }}_ exec rake test
+        bundle install --jobs 4 --retry 3
+        bundle exec rake test


### PR DESCRIPTION
ruby/setup-ruby action installs the appropriate bundler for each Ruby version.
If the combination is inappropriate, it may not work as expected.

Related to https://github.com/fluent/fluent-plugin-kafka/pull/526#issuecomment-2639114023